### PR TITLE
Test build/system directory to repo extraction

### DIFF
--- a/bin/centos71-devbuild.sh
+++ b/bin/centos71-devbuild.sh
@@ -20,7 +20,7 @@ DATE_STAMP=`date +"%Y%m%d_%T"`
 LOG_FILE="${LOG_DIR}/centos71_devbuild_${DATE_STAMP}.log"
 
 BUILD_OPTIONS="--type nightly --reference centos71"
-if [ "${1}" = "--repo" ]
+if [ "${1}" = "-B" ]
 then
   shift
   if [ -z "#{1}" ]
@@ -28,10 +28,10 @@ then
     echo "Must specify the repo to use for the ManageIQ config and kickstart files"
     exit 1
   fi
-  BUILD_OPTIONS="$BUILD_OPTIONS --repo ${1}"
+  BUILD_OPTIONS="$BUILD_OPTIONS -B ${1}"
   shift
 else
-  BUILD_OPTIONS="$BUILD_OPTIONS --repo http://github.com/abellotti/manageiq.git"
+  BUILD_OPTIONS="$BUILD_OPTIONS -B http://github.com/abellotti/manageiq-appliance-build.git"
 fi
 
 if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]

--- a/config/targets.yml
+++ b/config/targets.yml
@@ -1,8 +1,8 @@
 ---
 name: manageiq
 directory: upstream
-code: https://github.com/ManageIQ/manageiq.git
-appliance: https://github.com/ManageIQ/manageiq-appliance.git
+manageiq_git_url: https://github.com/ManageIQ/manageiq.git
+appliance_git_url: https://github.com/ManageIQ/manageiq-appliance.git
 targets:
   # Format:
   #   target: img_fac_target

--- a/config/targets.yml
+++ b/config/targets.yml
@@ -1,8 +1,6 @@
 ---
 name: manageiq
 directory: upstream
-manageiq_git_url: https://github.com/ManageIQ/manageiq.git
-appliance_git_url: https://github.com/ManageIQ/manageiq-appliance.git
 targets:
   # Format:
   #   target: img_fac_target

--- a/config/targets.yml
+++ b/config/targets.yml
@@ -1,7 +1,8 @@
 ---
 name: manageiq
 directory: upstream
-repository: https://github.com/ManageIQ/manageiq.git
+code: https://github.com/ManageIQ/manageiq.git
+appliance: https://github.com/ManageIQ/manageiq-appliance.git
 targets:
   # Format:
   #   target: img_fac_target

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -187,8 +187,7 @@ git checkout <%= @manageiq_checkout.branch %>
 git reset --hard <%= @manageiq_checkout.commit_sha %>
 
 # Symlink extracted repo (manageiq-appliance) to old /var/www/miq/system location.
-# this will change when we move system up a directory
-ln -vs $appliance_root/system $app_root/system
+ln -vs $appliance_root $app_root/system
 
 #### TODO: Refactor this so the cfme rpm and the upstream share much of this code.
 
@@ -198,32 +197,32 @@ mkdir -p /etc/httpd/conf.d
 pushd $appliance_root
   #symlink some executables
   mkdir -p /bin
-  pushd ./system/LINK/bin
+  pushd ./LINK/bin
     for filename in `ls`; do
-      ln -vs $appliance_root/system/LINK/bin/$filename /bin/$filename
+      ln -vs $appliance_root/LINK/bin/$filename /bin/$filename
     done
   popd
 
   #symlink some configuration files
-  pushd ./system/LINK/etc
+  pushd ./LINK/etc
     for dirname in `ls`; do
       pushd ./$dirname
         mkdir -p /etc/$dirname
         for filename in `ls`; do
-          ln -vs $appliance_root/system/LINK/etc/$dirname/$filename /etc/$dirname/$filename
+          ln -vs $appliance_root/LINK/etc/$dirname/$filename /etc/$dirname/$filename
         done
       popd
     done
   popd
 
-  pushd ./system/LINK
-    ln -vs $appliance_root/system/LINK/.toprc /.toprc
+  pushd ./LINK
+    ln -vs $appliance_root/LINK/.toprc /.toprc
   popd
 
   #copy etc dir from COPY
-  cp -vr system/COPY/etc /
+  cp -vr COPY/etc /
   #copy var dir from COPY
-  cp -vr system/COPY/var /
+  cp -vr COPY/var /
 popd
 
 # post install repos

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -215,9 +215,7 @@ pushd $appliance_root
     done
   popd
 
-  pushd ./LINK
-    ln -vs $appliance_root/LINK/.toprc /.toprc
-  popd
+  ln -vs $appliance_root/LINK/.toprc /.toprc
 
   #copy etc dir from COPY
   cp -vr COPY/etc /

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -181,10 +181,10 @@ pushd $appliance_root
   git reset --hard <%= @appliance_checkout.commit_sha %>
 popd
 
-git clone <%= @code_checkout.remote %> $app_root
+git clone <%= @manageiq_checkout.remote %> $app_root
 pushd $app_root
-git checkout <%= @code_checkout.branch %>
-git reset --hard <%= @code_checkout.commit_sha %>
+git checkout <%= @manageiq_checkout.branch %>
+git reset --hard <%= @manageiq_checkout.commit_sha %>
 
 # Symlink extracted repo (manageiq-appliance) to old /var/www/miq/system location.
 # this will change when we move system up a directory

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -186,6 +186,10 @@ pushd $app_root
 git checkout <%= @code_checkout.branch %>
 git reset --hard <%= @code_checkout.commit_sha %>
 
+# Symlink extracted repo (manageiq-appliance) to old /var/www/miq/system location.
+# this will change when we move system up a directory
+ln -vs $appliance_root/system $app_root/system
+
 #### TODO: Refactor this so the cfme rpm and the upstream share much of this code.
 
 mkdir -p $app_root/vmdb/log/apache

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -171,48 +171,55 @@ done
 
 www_root="/var/www"
 app_root="$www_root/miq"
+appliance_root="$www_root/manageiq-appliance"
 
 rm -rf $app_root
 
-git clone <%= @git_checkout.remote %> $app_root
-pushd $app_root
+git clone <%= @appliance_checkout.remote %> $appliance_root
+pushd $appliance_root
+  git checkout <%= @appliance_checkout.branch %>
+  git reset --hard <%= @appliance_checkout.commit_sha %>
+popd
 
-git checkout <%= @git_checkout.branch %>
-git reset --hard <%= @git_checkout.commit_sha %>
+git clone <%= @code_checkout.remote %> $app_root
+pushd $app_root
+git checkout <%= @code_checkout.branch %>
+git reset --hard <%= @code_checkout.commit_sha %>
 
 #### TODO: Refactor this so the cfme rpm and the upstream share much of this code.
 
 mkdir -p $app_root/vmdb/log/apache
 mkdir -p /etc/httpd/conf.d
 
-#symlink some executables
-mkdir -p /bin
-pushd ./system/LINK/bin
-  for filename in `ls`; do
-    ln -vs $app_root/system/LINK/bin/$filename /bin/$filename
-  done
-popd
+pushd $appliance_root
+  #symlink some executables
+  mkdir -p /bin
+  pushd ./system/LINK/bin
+    for filename in `ls`; do
+      ln -vs $appliance_root/system/LINK/bin/$filename /bin/$filename
+    done
+  popd
 
-#symlink some configuration files
-pushd ./system/LINK/etc
-  for dirname in `ls`; do
-    pushd ./$dirname
-      mkdir -p /etc/$dirname
-      for filename in `ls`; do
-        ln -vs $app_root/system/LINK/etc/$dirname/$filename /etc/$dirname/$filename
-      done
-    popd
-  done
-popd
+  #symlink some configuration files
+  pushd ./system/LINK/etc
+    for dirname in `ls`; do
+      pushd ./$dirname
+        mkdir -p /etc/$dirname
+        for filename in `ls`; do
+          ln -vs $appliance_root/system/LINK/etc/$dirname/$filename /etc/$dirname/$filename
+        done
+      popd
+    done
+  popd
 
-pushd ./system/LINK
-  ln -vs $app_root/system/LINK/.toprc /.toprc
-popd
+  pushd ./system/LINK
+    ln -vs $appliance_root/system/LINK/.toprc /.toprc
+  popd
 
-#copy etc dir from COPY
-cp -vr system/COPY/etc /
-#copy var dir from COPY
-cp -vr system/COPY/var /
+  #copy etc dir from COPY
+  cp -vr system/COPY/etc /
+  #copy var dir from COPY
+  cp -vr system/COPY/var /
 popd
 
 # post install repos

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -7,7 +7,7 @@ module Build
     ALLOWED_TYPES = %w(nightly test)
     DEFAULT_TYPE  = "nightly"
     DEFAULT_REF   = "master"
-    DEFAULT_REPO  = "http://github.com/ManageIQ/manageiq.git"
+    DEFAULT_REPO  = "http://github.com/ManageIQ/manageiq-appliance.git"
 
     def parse
       git_ref_desc  = "provide a git reference such as a branch or tag"

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -7,14 +7,18 @@ module Build
     ALLOWED_TYPES = %w(nightly test)
     DEFAULT_TYPE  = "nightly"
     DEFAULT_REF   = "master"
-    DEFAULT_REPO  = "http://github.com/ManageIQ/manageiq-appliance.git"
+    APPLIANCE_URL = "https://github.com/ManageIQ/manageiq-appliance.git"
+    BUILD_URL     = "https://github.com/ManageIQ/manageiq-appliance-build.git"
+    MANAGEIQ_URL  = "https://github.com/ManageIQ/manageiq.git"
 
     def parse
       git_ref_desc  = "provide a git reference such as a branch or tag"
       type_desc     = "build type: nightly, test, a named yum repository"
       local_desc    = "Use local config and kickstart for build"
       share_desc    = "Copy builds to file share"
-      repo_desc     = "repository to use for build config and kickstart"
+      appliance_desc = "Repo URL containing appliance scripts and configs(COPY/LINK/TEMPLATE)"
+      build_desc     = "Repo URL containing the build config and kickstart"
+      manageiq_desc  = "Repo URL containing the main manageiq code"
 
       @options = Trollop.options do
         banner "Usage: build.rb [options]"
@@ -23,7 +27,9 @@ module Build
         opt :reference,   git_ref_desc,  :type => :string,  :default => DEFAULT_REF,  :short => "r"
         opt :local,       local_desc,    :type => :boolean, :default => false,        :short => "l"
         opt :fileshare,   share_desc,    :type => :boolean, :default => true,         :short => "s"
-        opt :repo,        repo_desc,     :type => :string,  :default => DEFAULT_REPO, :short => "R"
+        opt :appliance_url, appliance_desc,  :type => :string,  :default => APPLIANCE_URL, :short => "A"
+        opt :build_url, build_desc, :type => :string,  :default => BUILD_URL, :short => "B"
+        opt :manageiq_url, manageiq_desc, :type => :string,  :default => MANAGEIQ_URL, :short => "M"
       end
 
       options[:type] &&= options[:type].strip

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -10,14 +10,15 @@ module Build
     KS_DIR     = "kickstarts"
     KS_GEN_DIR = "#{KS_DIR}/generated"
 
-    attr_reader :targets, :puddle, :git_checkout
+    attr_reader :targets, :puddle, :appliance_checkout, :code_checkout
 
-    def initialize(build_base, targets, puddle, git_checkout)
-      @build_base   = Pathname.new(build_base)
-      @ks_gen_base  = @build_base.join(KS_GEN_DIR)
-      @targets      = targets
-      @puddle       = puddle # used during ERB evaluation
-      @git_checkout = git_checkout
+    def initialize(build_base, targets, puddle, code_checkout, appliance_checkout)
+      @build_base         = Pathname.new(build_base)
+      @ks_gen_base        = @build_base.join(KS_GEN_DIR)
+      @targets            = targets
+      @puddle             = puddle # used during ERB evaluation
+      @appliance_checkout = appliance_checkout
+      @code_checkout      = code_checkout
     end
 
     def run(task = :all)

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -10,15 +10,15 @@ module Build
     KS_DIR     = "kickstarts"
     KS_GEN_DIR = "#{KS_DIR}/generated"
 
-    attr_reader :targets, :puddle, :appliance_checkout, :code_checkout
+    attr_reader :targets, :puddle, :appliance_checkout, :manageiq_checkout
 
-    def initialize(build_base, targets, puddle, code_checkout, appliance_checkout)
+    def initialize(build_base, targets, puddle, manageiq_checkout, appliance_checkout)
       @build_base         = Pathname.new(build_base)
       @ks_gen_base        = @build_base.join(KS_GEN_DIR)
       @targets            = targets
       @puddle             = puddle # used during ERB evaluation
       @appliance_checkout = appliance_checkout
-      @code_checkout      = code_checkout
+      @manageiq_checkout  = manageiq_checkout
     end
 
     def run(task = :all)

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -12,7 +12,7 @@ module Build
 
     attr_reader :targets, :puddle, :appliance_checkout, :manageiq_checkout
 
-    def initialize(build_base, targets, puddle, manageiq_checkout, appliance_checkout)
+    def initialize(build_base, targets, puddle, appliance_checkout, manageiq_checkout)
       @build_base         = Pathname.new(build_base)
       @ks_gen_base        = @build_base.join(KS_GEN_DIR)
       @targets            = targets

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -50,7 +50,7 @@ if !cli_options[:local] && cli_options[:build_url]
     `git fetch origin`                                    # Get origin updates
     `git reset --hard origin/#{cli_options[:reference]}`  # Reset the branch to the origin
   end
-  cfg_base = "#{cfg_base}/build"
+
   unless File.exist?(cfg_base)
     $log.error("Could not checkout repo #{build_repo} for reference #{cli_options[:reference]}")
     exit 1

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -83,13 +83,16 @@ directory_name    = "#{year_month_day}_#{hour_minute}"
 timestamp         = "#{year_month_day}#{hour_minute}"
 
 targets_config    = YAML.load_file(targets_file)
-name, directory, repo, targets = targets_config.values_at("name", "directory", "repository", "targets")
-git_checkout      = Build::GitCheckout.new(:remote => repo, :ref => cli_options[:reference])
+name, directory, code, appliance, targets =
+  targets_config.values_at("name", "directory", "code", "appliance", "targets")
+
+code_checkout      = Build::GitCheckout.new(:remote => code, :ref => cli_options[:reference])
+appliance_checkout = Build::GitCheckout.new(:remote => appliance, :ref => cli_options[:reference])
 
 file_rdu_dir_base = "#{FILE_SERVER_BASE}/#{directory}"
 file_rdu_dir      = "#{file_rdu_dir_base}/#{directory_name}"
 
-ks_gen            = Build::KickstartGenerator.new(cfg_base, targets.keys, puddle, git_checkout)
+ks_gen            = Build::KickstartGenerator.new(cfg_base, targets.keys, puddle, code_checkout, appliance_checkout)
 ks_gen.run
 
 FILE_TYPE = {
@@ -136,7 +139,7 @@ Dir.chdir(IMGFAC_DIR) do
     source      = "#{STORAGE_DIR}/#{uuid}.body"
 
     FileUtils.mkdir_p(destination_directory)
-    file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{git_checkout.commit_sha}.#{FILE_TYPE[imgfac_target]}"
+    file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{code_checkout.commit_sha}.#{FILE_TYPE[imgfac_target]}"
     destination = destination_directory.join(file_name)
     $log.info `mv #{source} #{destination}`
 

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -35,17 +35,16 @@ FILE_SERVER         = ENV["BUILD_FILE_SERVER"]             # SSH Server to host 
 FILE_SERVER_ACCOUNT = ENV["BUILD_FILE_SERVER_ACCOUNT"]     # Account to SSH as
 FILE_SERVER_BASE    = ENV["BUILD_FILE_SERVER_BASE"] || "." # Subdirectory of Account where to store builds
 
-if !cli_options[:local] && cli_options[:appliance_url]
-  # TODO: Split up appliance repo into appliance and appliance-build
-  appliance_repo = cli_options[:appliance_url]
+if !cli_options[:local] && cli_options[:build_url]
+  build_repo = cli_options[:build_url]
   cfg_base = "#{REFS_DIR}/#{cli_options[:reference]}"
   FileUtils.mkdir_p(cfg_base)
   Dir.chdir(cfg_base) do
     unless File.exist?(".git")
-      $log.info("Cloning Repo #{appliance_repo} to #{cfg_base} ...")
-      `git clone #{appliance_repo} .` unless File.exist?(".git")
+      $log.info("Cloning Repo #{build_repo} to #{cfg_base} ...")
+      `git clone #{build_repo} .` unless File.exist?(".git")
     end
-    $log.info("Checking out reference #{cli_options[:reference]} from repo #{appliance_repo} ...")
+    $log.info("Checking out reference #{cli_options[:reference]} from repo #{build_repo} ...")
     `git reset --hard`                                    # Drop any local changes
     `git checkout #{cli_options[:reference]}`             # Checkout existing branch
     `git fetch origin`                                    # Get origin updates
@@ -53,7 +52,7 @@ if !cli_options[:local] && cli_options[:appliance_url]
   end
   cfg_base = "#{cfg_base}/build"
   unless File.exist?(cfg_base)
-    $log.error("Could not checkout repo #{appliance_repo} for reference #{cli_options[:reference]}")
+    $log.error("Could not checkout repo #{build_repo} for reference #{cli_options[:reference]}")
     exit 1
   end
 else

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -93,7 +93,7 @@ appliance_checkout = Build::GitCheckout.new(:remote => appliance_git_url, :ref =
 file_rdu_dir_base = "#{FILE_SERVER_BASE}/#{directory}"
 file_rdu_dir      = "#{file_rdu_dir_base}/#{directory_name}"
 
-ks_gen            = Build::KickstartGenerator.new(cfg_base, targets.keys, puddle, manageiq_checkout, appliance_checkout)
+ks_gen            = Build::KickstartGenerator.new(cfg_base, targets.keys, puddle, appliance_checkout, manageiq_checkout)
 ks_gen.run
 
 FILE_TYPE = {

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -83,16 +83,16 @@ directory_name    = "#{year_month_day}_#{hour_minute}"
 timestamp         = "#{year_month_day}#{hour_minute}"
 
 targets_config    = YAML.load_file(targets_file)
-name, directory, code, appliance, targets =
-  targets_config.values_at("name", "directory", "code", "appliance", "targets")
+name, directory, manageiq_git_url, appliance_git_url, targets =
+  targets_config.values_at("name", "directory", "manageiq_git_url", "appliance_git_url", "targets")
 
-code_checkout      = Build::GitCheckout.new(:remote => code, :ref => cli_options[:reference])
-appliance_checkout = Build::GitCheckout.new(:remote => appliance, :ref => cli_options[:reference])
+manageiq_checkout  = Build::GitCheckout.new(:remote => manageiq_git_url, :ref => cli_options[:reference])
+appliance_checkout = Build::GitCheckout.new(:remote => appliance_git_url, :ref => cli_options[:reference])
 
 file_rdu_dir_base = "#{FILE_SERVER_BASE}/#{directory}"
 file_rdu_dir      = "#{file_rdu_dir_base}/#{directory_name}"
 
-ks_gen            = Build::KickstartGenerator.new(cfg_base, targets.keys, puddle, code_checkout, appliance_checkout)
+ks_gen            = Build::KickstartGenerator.new(cfg_base, targets.keys, puddle, manageiq_checkout, appliance_checkout)
 ks_gen.run
 
 FILE_TYPE = {
@@ -139,7 +139,7 @@ Dir.chdir(IMGFAC_DIR) do
     source      = "#{STORAGE_DIR}/#{uuid}.body"
 
     FileUtils.mkdir_p(destination_directory)
-    file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{code_checkout.commit_sha}.#{FILE_TYPE[imgfac_target]}"
+    file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{manageiq_checkout.commit_sha}.#{FILE_TYPE[imgfac_target]}"
     destination = destination_directory.join(file_name)
     $log.info `mv #{source} #{destination}`
 


### PR DESCRIPTION
Summary of changes:

* Before, the build code worked with a single manageiq repository containing the build and system directories.
* Now, it works with 3 separate repositories (manageiq, manageiq-appliance (former system), and manageiq-appliance-build (former build)
* CLI now accepts 3 repos via -A(--appliance_url), -B(--build_url), and -M(--manageiq_url) or defaults to the ones in the manageiq organization.  The repo is not read from the targets.yml anymore.  The `--repo` option in the CLI was removed as it's now unclear with 3 repos.
* Note:  all 3 repos must have the `--reference` so you need to create branches and tags on each repo to do a build.
* Destination appliance will have manage-appliance checked out in /var/www/manageiq-appliance with a symlink from /var/www/miq/system -> /var/www/manageiq-appliance (for backward compatility)

Example test build command line:

```
ruby /build/scripts/vmbuild.rb -A https://github.com/jrafanie/manageiq-appliance.git -B https://github.com/jrafanie/manageiq-appliance-build.git -M https://github.com/jrafanie/manageiq.git --reference test_build_system_repo_extraction
```

@abellotti @chessbyte Please review.

Note, the appliances build and I get the error during rake assets:precompile because of this: https://github.com/ManageIQ/manageiq/issues/3285, @kbrock is trying to solve that one.

Workers do start properly after reboot though.

Once this is merged, we can then review/merge: https://github.com/ManageIQ/manageiq/issues/3295