### PR TITLE
Fix appliance build after vmdb reroot

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -181,10 +181,12 @@ pushd $appliance_root
   git reset --hard <%= @appliance_checkout.commit_sha %>
 popd
 
-git clone <%= @manageiq_checkout.remote %> $app_root
-pushd $app_root
-git checkout <%= @manageiq_checkout.branch %>
-git reset --hard <%= @manageiq_checkout.commit_sha %>
+mkdir -p $app_root
+git clone <%= @manageiq_checkout.remote %> $app_root/vmdb
+pushd $app_root/vmdb
+  git checkout <%= @manageiq_checkout.branch %>
+  git reset --hard <%= @manageiq_checkout.commit_sha %>
+popd
 
 # Symlink extracted repo (manageiq-appliance) to old /var/www/miq/system location.
 ln -vs $appliance_root $app_root/system

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -161,6 +161,10 @@ open-vm-tools
 
 %post --log=/root/anaconda-post.log
 
+# For some reason, DEBUG is set but empty in the kickstart.
+# Unset it so ruby_parser doesn't print LOTS of output.
+unset DEBUG
+
 # Drop packets for INPUT/FORWARD that aren't whitelisted in the firewall setup
 for IPT in /etc/sysconfig/iptables /etc/sysconfig/iptables.old ; do
   if [ -f $IPT ] ; then


### PR DESCRIPTION
* Clone manageiq.git into vmdb since the repo is the contents of vmdb.
This fixes the appliance build to work with the rerooted manageiq repo:
ManageIQ/manageiq#3363

* For some reason, DEBUG is set but empty in the kickstart ¯\_(ツ)_/¯. …
Unset it so ruby_parser doesn't print LOTS of output.
Fixes #5