### PR TITLE
Symlink the nightly build script to /etc/cron.daily.

### DIFF
--- a/docs/creating_build_vm.txt
+++ b/docs/creating_build_vm.txt
@@ -316,3 +316,9 @@ Note:
 vncviewer has an "F8" menu we need to use if we want to send an "alt" keypress to the VM.
 On t540p thinkpad, with the function lock key on, pressing F8 actually disables WIFI.
 
+________________________________________________________________________________
+To setup a daily build:
+
+We'll symlink the nightly-build to the cron.daily directory:
+
+ln -s /build/bin/nightly-build.sh /etc/cron.daily


### PR DESCRIPTION
Please review @abellotti @brandondunne 

It's the easiest thing I could find.  I don't think we care when at night it runs but it looks like it's defaulted to run every day around 3:05 AM.

I think that's ok and this makes the setup :cake: 

```
>  cat /etc/anacrontab
...
# the maximal random delay added to the base delay of the jobs
RANDOM_DELAY=45
# the jobs will be started during the following hours only
START_HOURS_RANGE=3-22

#period in days   delay in minutes   job-identifier   command
1	5	cron.daily		nice run-parts /etc/cron.daily
7	25	cron.weekly		nice run-parts /etc/cron.weekly
@monthly 45	cron.monthly		nice run-parts /etc/cron.monthly
```