### PR TITLE
Add SHA256 checksums to VM based builds

### DIFF
--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -156,6 +156,12 @@ Dir.chdir(IMGFAC_DIR) do
       end
     end
   end
+  $log.info "Generating image checksums"
+  Dir.chdir(destination_directory) do
+    $log.info `/usr/bin/sha256sum * > SHA256SUM`
+    $log.info `/usr/bin/gpg --batch --no-tty --passphrase-file /root/.gnupg/pass -b SHA256SUM`
+    FileUtils.cp("/root/.gnupg/cfme_public.key", destination_directory)
+  end
 end
 
 # Only update the symlink for a nightly

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -24,6 +24,7 @@ else
 end
 
 BUILD_BASE          = "/build"
+GPG_DIR             = "/root/.gnupg"
 CFG_DIR             = "#{BUILD_BASE}/config"
 FILESHARE_DIR       = "#{BUILD_BASE}/fileshare"
 REFS_DIR            = "#{BUILD_BASE}/references"
@@ -156,11 +157,15 @@ Dir.chdir(IMGFAC_DIR) do
       end
     end
   end
-  $log.info "Generating image checksums"
-  Dir.chdir(destination_directory) do
-    $log.info `/usr/bin/sha256sum * > SHA256SUM`
-    $log.info `/usr/bin/gpg --batch --no-tty --passphrase-file /root/.gnupg/pass -b SHA256SUM`
-    FileUtils.cp("/root/.gnupg/cfme_public.key", destination_directory)
+  passphrase_file = "#{GPG_DIR}/pass"
+  public_key_file = "#{GPG_DIR}/manageiq_public.key"
+  if File.exist?(passphrase_file) && File.exist?(public_key_file)
+    $log.info "Generating Image Checksums in #{destination_directory} ..."
+    Dir.chdir(destination_directory) do
+      $log.info `/usr/bin/sha256sum * > SHA256SUM`
+      $log.info `/usr/bin/gpg --batch --no-tty --passphrase-file #{passphrase_file} -b SHA256SUM`
+      FileUtils.cp(public_key_file, destination_directory)
+    end
   end
 end
 


### PR DESCRIPTION
- Merge John P's commit to add SHA256 checksums.
- Minor update:
  * Only create the signatures if the needed GPG files exist on the build VM, not all build VMs will have those.
  * Use manageiq_public.key for upstream builds.

![screen shot 2015-07-08 at 10 32 03 pm](https://cloud.githubusercontent.com/assets/5797328/8586861/e4e3cea4-25c1-11e5-8ba5-e0b673f10ba6.png)

