### PR TITLE
Use relative paths to the "latest" symlink.

### DIFF
--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -170,21 +170,24 @@ Dir.chdir(IMGFAC_DIR) do
   end
 end
 
-# Only update the symlink for a nightly
+# Only update the latest symlink for a nightly
 unless build_label == "test"
-  link = stream_directory.join("latest")
+  symlink_name = "latest"
+  link = stream_directory.join(symlink_name)
   if File.exist?(link)
     raise "#{link} is not a symlink!" unless File.symlink?(link)
     result = FileUtils.rm(link, :verbose => true)
     $log.info("Deleted symlink: #{result}")
   end
 
-  result = FileUtils.ln_s(destination_directory, link, :verbose => true)
-  $log.info("Created symlink: #{result}")
+  Dir.chdir(stream_directory) do
+    result = FileUtils.ln_s(directory_name, symlink_name, :verbose => true)
+    $log.info("Created symlink: #{result}")
+  end
 
   if cli_options[:fileshare] && FILE_SERVER
-    $log.info "Updating latest symlink on #{FILE_SERVER} ..."
-    ssh_cmd = "cd #{file_rdu_dir_base}; rm -f latest; ln -s #{directory_name} latest"
+    $log.info "Updating #{symlink_name} symlink on #{FILE_SERVER} ..."
+    ssh_cmd = "cd #{file_rdu_dir_base}; rm -f #{symlink_name}; ln -s #{directory_name} #{symlink_name}"
     $log.info `ssh #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER} "#{ssh_cmd}"`
   end
 end


### PR DESCRIPTION
Updated the vmbuild.rb script so that "latest" symlinks are created with relative path to the target directories.

This allows the latest links to be traversed from different VM build servers that cross mount the fileshare.

![screen shot 2015-07-09 at 1 53 50 pm](https://cloud.githubusercontent.com/assets/5797328/8602847/90278d84-2642-11e5-8056-8d11d3b6d030.png)

@jrafanie please review/merge.

@JPrause this will allow users to go to the kegerator subdirectory that they see off virtlab31 or aab-brewery7 and see and be able to click on the latest symlink.
