### PR TITLE
Install wmi on appliance build.

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -127,6 +127,8 @@ openldap-clients
 
 cloud-init
 
+wmi
+
 <% if @target == "ovirt" %>
 ovirt-guest-agent
 <% elsif @target == "vsphere" %>
@@ -169,8 +171,6 @@ open-vm-tools
 %end
 
 %post --log=/root/anaconda-post.log
-
-yum -y install http://www6.atomicorp.com/channels/atomic/centos/7/x86_64/RPMS/wmi-1.3.14-4.el7.art.x86_64.rpm
 
 exec < /dev/tty3 > /dev/tty3
 chvt 3

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -170,6 +170,8 @@ open-vm-tools
 
 %post --log=/root/anaconda-post.log
 
+yum -y install http://www6.atomicorp.com/channels/atomic/centos/7/x86_64/RPMS/wmi-1.3.14-4.el7.art.x86_64.rpm
+
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 set -x


### PR DESCRIPTION
The wmic tool is needed to get running processes from windows machines.
This PR is also needed for https://github.com/ManageIQ/manageiq/pull/3540
https://bugzilla.redhat.com/show_bug.cgi?id=1233815