### PR TITLE
Add cloud init to appliance

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -328,7 +328,7 @@ mkdir /var/log/journal
 systemctl restart systemd-journald
 
 # Alter cloud-init config to allow root ssh access to the appliance
-[[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^ssh_pwauth:.*$/ssh_pwauth: \"unchanged\"/g" /etc/cloud/cloud.cfg
+[[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^ssh_pwauth:.*$/ssh_pwauth: True/g" /etc/cloud/cloud.cfg
 [[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^disable_root:.*$/disable_root: false/g" /etc/cloud/cloud.cfg
 
 # Alter cloud-init logging config to prevent logging to the console

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -327,9 +327,14 @@ ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 mkdir /var/log/journal
 systemctl restart systemd-journald
 
-# Alter clout-init config to allow root ssh access to the appliance
+# Alter cloud-init config to allow root ssh access to the appliance
 [[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^ssh_pwauth:.*$/ssh_pwauth: \"unchanged\"/g" /etc/cloud/cloud.cfg
 [[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^disable_root:.*$/disable_root: false/g" /etc/cloud/cloud.cfg
+
+# Alter cloud-init logging config to prevent logging to the console
+[[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/handlers=consoleHandler,cloudLogHandler/handlers=cloudLogHandler/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
+[[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "/^ - \[ \*log_base, \*log_syslog \]/d" /etc/cloud/cloud.cfg.d/05_logging.cfg
+[[ -s /etc/cloud/cloud.cfg.d/05_logging.cfg ]] && sed -i "s/^output:.*$/output: {all: '| tee -a \/var\/log\/cloud-init-output\.log \&> \/dev\/null'}/g" /etc/cloud/cloud.cfg.d/05_logging.cfg
 
 # Create a script to initialize appliance on first boot
 cat > /bin/appliance-initialize.sh <<EOF

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -327,6 +327,10 @@ ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 mkdir /var/log/journal
 systemctl restart systemd-journald
 
+# Alter clout-init config to allow root ssh access to the appliance
+[[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^ssh_pwauth:.*$/ssh_pwauth: \"unchanged\"/g" /etc/cloud/cloud.cfg
+[[ -s /etc/cloud/cloud.cfg ]] && sed -i "s/^disable_root:.*$/disable_root: false/g" /etc/cloud/cloud.cfg
+
 # Create a script to initialize appliance on first boot
 cat > /bin/appliance-initialize.sh <<EOF
 #!/bin/sh

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -122,6 +122,8 @@ sssd
 adcli
 samba-common
 
+cloud-init
+
 <% if @target == "ovirt" %>
 ovirt-guest-agent
 <% elsif @target == "vsphere" %>


### PR DESCRIPTION
Adds cloud-init package and some configuration alterations to prevent the default config from preventing root ssh access and to log only to a file, rather than to the console.