### PR TITLE
Postgresql94 cleanup

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -246,12 +246,8 @@ pushd $appliance_root
 
   ln -vs $appliance_root/LINK/.toprc /.toprc
 
-  #copy etc dir from COPY
-  cp -vr COPY/etc /
-  #copy var dir from COPY
-  cp -vr COPY/var /
-  # copy usr dir from COPY
-  cp -vr COPY/usr /
+  #copy all files/directories below COPY
+  cp -vr COPY/* /
 popd
 
 # post install repos


### PR DESCRIPTION
I noticed some cleanup while testing pg94 in #19.

The only directories within COPY are now etc, var, and usr (we no longer have files we don't want to copy in opt) and we want to copy them all so let's blindly copy all files below COPY as that is most people would expect.