### PR TITLE
External Authentication - Adding support for LDAP

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -122,6 +122,9 @@ sssd
 adcli
 samba-common
 
+# External Authentication - LDAP
+openldap-clients
+
 cloud-init
 
 <% if @target == "ovirt" %>


### PR DESCRIPTION
- Adding the openldap-clients package (ldapsearch, etc.), these tools are commonly
used when debugging manual configurations of OpenLDAP, certificates from directory
servers and such before diving into sssd.conf.

https://trello.com/c/SIOuHAMk/87-auth-3-support-ldap-authentication-via-sssd