### PR TITLE
v2_key no longer exists by default

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -299,9 +299,6 @@ popd
 
 /var/www/miq/system/cfme-setup.sh
 
-# Remove the key from the source code, we'll generate on first boot
-rm -f /var/www/miq/vmdb/certs/v2_key
-
 # Enable top(1) and vmstat(1) data logging
 systemctl enable miqtop
 systemctl enable miqvmstat


### PR DESCRIPTION
Depends on: https://github.com/ManageIQ/manageiq/pull/4082

@kbrock Please review, @Fryguy helped me on both 4082 and this one.