### PR TITLE
Appliance repo shouldn't be in www root.

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -200,7 +200,7 @@ firewall-offline-cmd --zone=manageiq --add-service=postgresql
 
 www_root="/var/www"
 app_root="$www_root/miq"
-appliance_root="$www_root/manageiq-appliance"
+appliance_root="/opt/manageiq/manageiq-appliance"
 
 rm -rf $app_root
 


### PR DESCRIPTION
manage-appliance repo shouldn't be in www root.

Related PRs:
* https://github.com/ManageIQ/manageiq-appliance-build/pull/33 [ clone repo in new location ] 
* https://github.com/ManageIQ/manageiq-appliance/pull/12  [set environment variable for new location]
* https://github.com/ManageIQ/manageiq/pull/4105 [use environment variable above] 