### PR TITLE
Add fog based appliance build uploader which runs after each nightly.

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -1,0 +1,73 @@
+require 'fog'
+
+module Build
+  class Uploader
+    attr_reader :directory
+
+    def self.upload(directory)
+      new(directory).run
+    end
+
+    def initialize(directory)
+      @directory = directory
+    end
+
+    def service
+      # Example config/upload.yml
+      # ---
+      # :provider: XYZ
+      # :rackspace_username: MyUser
+      # :rackspace_api_key: MyKey
+      # :rackspace_region: :my_region
+      @service ||= Fog::Storage.new(YAML.load_file("#{__dir__}/../config/upload.yml"))
+    end
+
+    def container
+      @container ||= service.directories.get("release")
+    end
+
+    def run
+      appliances = Dir.glob("#{directory}/manageiq*")
+      appliances.each do |appliance|
+        # Skip badly named appliances, missing git sha: manageiq-openstack-master-201407142000-.qc2
+        next unless appliance.match(/.+-[0-9]{12}-[0-9a-fA-F]+/)
+        key = uploaded_filename(appliance)
+        puts "Uploading #{appliance} as #{key}..."
+        upload_file = File.expand_path(appliance)
+        file = container.files.create :key => key, :body => File.open(upload_file, "r")
+        url = file.public_url if file
+        puts "Uploading #{appliance} as #{key}...complete: #{url}"
+      end
+    end
+
+    # prerelease: manageiq-ovirt-anand-1-rc1.ova
+    # stable:     manageiq-ovirt-anand-1.ova
+
+    # Nightly builds:
+    # (YYYYMMDD): Build date or date of most recent commit
+    # sha1:       git sha1 of the most recent commit for that appliance build
+    # a nightly:        manageiq-${platform}-master-${YYYYMMDD}-${sha1}.${ext}
+    #                   manageiq-ovirt-master-20140613-8d9d1b8.ova
+    def uploaded_filename(appliance_name)
+      filename =
+        if appliance_name.include?("-master-")
+          nightly_filename(appliance_name)
+        else
+          release_filename(appliance_name)
+        end
+      File.basename(filename)
+    end
+
+    def nightly_filename(appliance_name)
+      name = appliance_name.split("-")
+      name[-2] = name[-2][0, 8]
+      name.join("-")
+    end
+
+    def release_filename(appliance_name)
+      ext = File.extname(appliance_name)
+      name = appliance_name.split("-")
+      name[0..-3].join("-") << ext
+    end
+  end
+end

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -8,6 +8,8 @@ require_relative 'productization'
 require_relative 'kickstart_generator'
 require_relative 'git_checkout'
 require_relative 'cli'
+require_relative 'uploader'
+
 $log = Logger.new(STDOUT)
 
 cli_options = Build::Cli.parse.options
@@ -171,7 +173,7 @@ Dir.chdir(IMGFAC_DIR) do
 end
 
 # Only update the latest symlink for a nightly
-unless build_label == "test"
+if cli_options[:type] == "nightly"
   symlink_name = "latest"
   link = stream_directory.join(symlink_name)
   if File.exist?(link)
@@ -188,4 +190,6 @@ unless build_label == "test"
     ssh_cmd = "cd #{file_rdu_dir_base}; rm -f #{symlink_name}; ln -s #{directory_name} #{symlink_name}"
     $log.info `ssh #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER} "#{ssh_cmd}"`
   end
+
+  Build::Uploader.upload(destination_directory)
 end


### PR DESCRIPTION
It assumes we want to upload all of the appliances in a build directory.

We can clean this up further to incorporate the normal logger facility of the build script but this will allow us to upload when a nightly build completes.

We can also use the Build::Uploader class to upload release builds.

@Fryguy Please review