### PR TITLE
Add new --upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,11 @@
 
   ```
   yum install ruby
+  yum install ruby-devel
+  yum install zlib-devel
+
   gem install trollop
+  gem install fog
   ```
 
   * For enabling copying to SSH file server, define the following in Root's .bashrc (optional)

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -18,7 +18,7 @@ mkdir -p ${LOG_DIR}
 
 DATE_STAMP=`date +"%Y%m%d_%T"`
 LOG_FILE="${LOG_DIR}/upstream_${DATE_STAMP}.log"
-BUILD_OPTIONS="--type nightly"
+BUILD_OPTIONS="--type nightly --upload"
 
 if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]
 then

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -19,7 +19,7 @@ module Build
       appliance_desc = "Repo URL containing appliance scripts and configs(COPY/LINK/TEMPLATE)"
       build_desc     = "Repo URL containing the build config and kickstart"
       manageiq_desc  = "Repo URL containing the main manageiq code"
-      upload_desc    = "Upload nightly build to release builds"
+      upload_desc    = "Upload appliance builds to the website"
 
       @options = Trollop.options do
         banner "Usage: build.rb [options]"

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -12,24 +12,26 @@ module Build
     MANAGEIQ_URL  = "https://github.com/ManageIQ/manageiq.git"
 
     def parse
-      git_ref_desc  = "provide a git reference such as a branch or tag"
-      type_desc     = "build type: nightly, test, a named yum repository"
-      local_desc    = "Use local config and kickstart for build"
-      share_desc    = "Copy builds to file share"
+      git_ref_desc   = "provide a git reference such as a branch or tag"
+      type_desc      = "build type: nightly, test, a named yum repository"
+      local_desc     = "Use local config and kickstart for build"
+      share_desc     = "Copy builds to file share"
       appliance_desc = "Repo URL containing appliance scripts and configs(COPY/LINK/TEMPLATE)"
       build_desc     = "Repo URL containing the build config and kickstart"
       manageiq_desc  = "Repo URL containing the main manageiq code"
+      upload_desc    = "Upload nightly build to release builds"
 
       @options = Trollop.options do
         banner "Usage: build.rb [options]"
 
-        opt :type,        type_desc,     :type => :string,  :default => DEFAULT_TYPE, :short => "t"
-        opt :reference,   git_ref_desc,  :type => :string,  :default => DEFAULT_REF,  :short => "r"
-        opt :local,       local_desc,    :type => :boolean, :default => false,        :short => "l"
-        opt :fileshare,   share_desc,    :type => :boolean, :default => true,         :short => "s"
-        opt :appliance_url, appliance_desc,  :type => :string,  :default => APPLIANCE_URL, :short => "A"
-        opt :build_url, build_desc, :type => :string,  :default => BUILD_URL, :short => "B"
-        opt :manageiq_url, manageiq_desc, :type => :string,  :default => MANAGEIQ_URL, :short => "M"
+        opt :type,          type_desc,      :type => :string,  :default => DEFAULT_TYPE,  :short => "t"
+        opt :reference,     git_ref_desc,   :type => :string,  :default => DEFAULT_REF,   :short => "r"
+        opt :local,         local_desc,     :type => :boolean, :default => false,         :short => "l"
+        opt :fileshare,     share_desc,     :type => :boolean, :default => true,          :short => "s"
+        opt :appliance_url, appliance_desc, :type => :string,  :default => APPLIANCE_URL, :short => "A"
+        opt :build_url,     build_desc,     :type => :string,  :default => BUILD_URL,     :short => "B"
+        opt :manageiq_url,  manageiq_desc,  :type => :string,  :default => MANAGEIQ_URL,  :short => "M"
+        opt :upload,        upload_desc,    :type => :boolean, :default => false,         :short => "u"
       end
 
       options[:type] &&= options[:type].strip

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -191,5 +191,5 @@ if cli_options[:type] == "nightly"
     $log.info `ssh #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER} "#{ssh_cmd}"`
   end
 
-  Build::Uploader.upload(destination_directory)
+  Build::Uploader.upload(destination_directory) if cli_options[:upload]
 end


### PR DESCRIPTION
we don't want to upload nightlies as release builds from all VM build machines,  only from the
real build machine, i.e. if run from the cron via bin/nightly-build.sh.  Also updated README.md for the
required fog gem.
