### PR TITLE
Add support for lib/tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+Dir.glob(File.expand_path("lib/tasks/*", __dir__)).sort.each { |f| require f }
+
 require_relative 'scripts/productization'
 require 'pathname'
 


### PR DESCRIPTION
This allows us to remove some of the downstream specifics from the Rakefile in a follow up PR.