### PR TITLE
Add release build script

### DIFF
--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -6,12 +6,8 @@
 # fileshare: true
 #
 
-CUR_BUILD="`virsh list | sed '1,2d'`"
-if [ -n "${CUR_BUILD}" ]
-then
-  echo "Current ImageFactory Build ongoing, cannot kick-off nightly build"
-  exit 1
-fi
+source '/build/bin/shared_functions.sh'
+stop_on_existing_build
 
 LOG_DIR=/build/logs
 mkdir -p ${LOG_DIR}

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+source '/build/bin/shared_functions.sh'
+stop_on_existing_build
+
+if [[ $# != 1 ]]; then
+  echo "Wrong number of arguments: $#. Usage example: release-build.sh capablanca-1-alpha1"
+  exit 1
+fi
+
+log_file="/build/logs/${1}.log"
+nohup time ruby /build/scripts/vmbuild.rb --type nightly --upload --reference $1 > $log_file 2>&1 &
+echo "${1} release build kicked off, see log @ $log_file ..."

--- a/bin/shared_functions.sh
+++ b/bin/shared_functions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+stop_on_existing_build ()
+{
+  CUR_BUILD="`virsh list | sed '1,2d'`"
+  if [ -n "${CUR_BUILD}" ]
+  then
+    echo "Current ImageFactory Build ongoing, cannot kick-off build"
+    exit 1
+  fi
+}


### PR DESCRIPTION
From a build vm, you can now build any tag or branch (release) found on each of
the repositories, manageiq, manageiq-appliance, and
manageiq-appliance-build by running:

`./release-build.sh capablanca-1-alpha1`

cc @abellotti @carbonin @simaishi @Fryguy 

Note, this assumes you want to upload the release to the website also.