### PR TITLE
Added enable for cloud-init datasource check

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -6,6 +6,8 @@ systemctl enable evminit
 systemctl enable evmserverd
 systemctl enable evm-watchdog
 
+systemctl enable cloud-ds-check
+
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 


### PR DESCRIPTION
Added the line in the kickstart post section to enable the service that runs the script to determine which cloud-init datasources to use on boot.

For https://github.com/ManageIQ/manageiq-appliance/pull/20