### PR TITLE
Stopped and disabled NetworkManager

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -14,3 +14,6 @@ ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 # Create the journal directory to enable persistant logging
 mkdir /var/log/journal
 systemctl restart systemd-journald
+
+systemctl stop NetworkManager
+systemctl disable NetworkManager


### PR DESCRIPTION
We don't need it and it makes configuring static IPs by editing files by hand less reliable.