### PR TITLE
Remove the line that enables evmserverd

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -3,7 +3,6 @@ systemctl enable miqtop
 systemctl enable miqvmstat
 
 systemctl enable evminit
-systemctl enable evmserverd
 systemctl enable evm-watchdog
 
 systemctl enable cloud-ds-check


### PR DESCRIPTION
The service will be enabled and started after the database is configured
by the changes in https://github.com/ManageIQ/manageiq/pull/4989

https://bugzilla.redhat.com/show_bug.cgi?id=1272604