### PR TITLE
Put the DEVICE line in ifcfg files if missing

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -67,6 +67,14 @@ $appliance_root/cfme-setup.sh
 
 <%= render_partial "post/db_init" %>
 
+# make sure we have the device name in all ifcfg-* files
+ls /etc/sysconfig/network-scripts/ifcfg-* | while read FILE
+do
+  # parse the device name from FILE
+  DEVICE=${FILE##*-}
+  grep -q 'DEVICE=' $FILE && echo "DEVICE=$DEVICE" >> $FILE
+done
+
 # Let's rebuild the ramfs with with base scsi drivers we need
 kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"


### PR DESCRIPTION
Ensures that we will have valid interface configuration at first boot.

@simaishi @bdunne @abellotti @gtanzillo 