### PR TITLE
Add vhd support for Hyper-V/SVCMM

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -78,7 +78,7 @@ done
 # Let's rebuild the ramfs with with base scsi drivers we need
 kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"
-/sbin/dracut --force --add-drivers "mptbase mptscsih mptspi" $ramfsfile $kversion
+/sbin/dracut --force --add-drivers "mptbase mptscsih mptspi<%= " hv_storvsc hid_hyperv hv_netvsc hv_vmbus" if @target == "hyperv" %>" $ramfsfile $kversion
 
 chvt 1
 %end

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -34,10 +34,14 @@ module Build
         opt :build_url,     build_desc,     :type => :string,  :short => "B", :default => BUILD_URL
         opt :manageiq_url,  manageiq_desc,  :type => :string,  :short => "M", :default => MANAGEIQ_URL
         opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
-        opt :only,          only_desc,      :type => :strings, :short => "o", :default => Target.supported_types
+        opt :only,          only_desc,      :type => :strings, :short => "o", :default => Target.default_types
       end
 
       options[:type] &&= options[:type].strip
+
+      if options[:only].include?('all')
+        options[:only] = Target.supported_types
+      end
 
       Trollop.die(:reference, git_ref_desc) if options[:reference].to_s.empty?
       options[:reference] = options[:reference].to_s.strip

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,7 +4,11 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack)
+    end
+
+    it "all" do
+      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv)
     end
 
     it "only vsphere and ovirt" do

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,7 +4,7 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv)
     end
 
     it "only vsphere and ovirt" do

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -26,7 +26,7 @@ describe Build::Target do
   end
 
   it ".supported_types" do
-    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere)
+    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv)
   end
 
   it "#to_s" do

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -29,6 +29,10 @@ describe Build::Target do
     expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv)
   end
 
+  it ".default_types" do
+    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere)
+  end
+
   it "#to_s" do
     expect(described_class.new("vsphere").to_s).to eql "vsphere"
   end

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -5,7 +5,8 @@ module Build
     TYPES = {
       'vsphere'   => ImagefactoryMetadata.new('vsphere', 'ova'),
       'ovirt'     => ImagefactoryMetadata.new('rhevm', 'ova'),
-      'openstack' => ImagefactoryMetadata.new('openstack-kvm', 'qc2')
+      'openstack' => ImagefactoryMetadata.new('openstack-kvm', 'qc2'),
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', 'vhd')
     }
 
     attr_reader :name

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -15,6 +15,10 @@ module Build
       TYPES.keys
     end
 
+    def self.default_types
+      supported_types - ["hyperv"]
+    end
+
     def initialize(name)
       @name = name = name.to_s
       raise ArgumentError, "Unsupported name: #{name}" unless TYPES.key?(name)


### PR DESCRIPTION
Tested by building/deploying hyperv and vsphere images with this change.

Note: Depending on the version of qemu-img on the machine, the final image could be the same size as the disk size.  CentOS 7.1 produced 40GB image, Fedora22 produced 3.8GB image.  Use -o to limit type of images to build as needed.