### PR TITLE
Add a new line to /etc/ssh/sshd_config

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -73,6 +73,9 @@ do
   grep -q 'DEVICE=' $FILE || echo "DEVICE=$DEVICE" >> $FILE
 done
 
+# make sure there is a new line at the end of sshd_config
+echo "" >> /etc/ssh/sshd_config
+
 # Let's rebuild the ramfs with with base scsi drivers we need
 kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"


### PR DESCRIPTION
The current scap-security-guide remediations for the sshd_config
file don't check if there is a new line and append fixes anyway.
This will cause the first fix to share a line with whatever is
at the end of the file.

https://bugzilla.redhat.com/show_bug.cgi?id=1219230
https://bugzilla.redhat.com/show_bug.cgi?id=1219227
https://bugzilla.redhat.com/show_bug.cgi?id=1219231
https://bugzilla.redhat.com/show_bug.cgi?id=1219229
https://bugzilla.redhat.com/show_bug.cgi?id=1219228