### PR TITLE
Added 'release' type for build options

### DIFF
--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -10,5 +10,5 @@ if [[ $# != 1 ]]; then
 fi
 
 log_file="/build/logs/${1}.log"
-nohup time ruby /build/scripts/vmbuild.rb --type nightly --upload --reference $1 > $log_file 2>&1 &
+nohup time ruby /build/scripts/vmbuild.rb --type release --upload --reference $1 > $log_file 2>&1 &
 echo "${1} release build kicked off, see log @ $log_file ..."

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -5,7 +5,7 @@ require_relative 'target'
 module Build
   class Cli
     attr_reader :options
-    ALLOWED_TYPES = %w(nightly test)
+    ALLOWED_TYPES = %w(nightly release test)
     DEFAULT_TYPE  = "nightly"
     DEFAULT_REF   = "master"
     APPLIANCE_URL = "https://github.com/ManageIQ/manageiq-appliance.git"
@@ -13,8 +13,8 @@ module Build
     MANAGEIQ_URL  = "https://github.com/ManageIQ/manageiq.git"
 
     def parse(args = ARGV)
-      git_ref_desc   = "provide a git reference such as a branch or tag"
-      type_desc      = "build type: nightly, test, a named yum repository"
+      git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"
+      type_desc      = "build type: nightly, release, test, a named yum repository"
       local_desc     = "Use local config and kickstart for build"
       share_desc     = "Copy builds to file share"
       appliance_desc = "Repo URL containing appliance scripts and configs(COPY/LINK/TEMPLATE)"
@@ -45,6 +45,10 @@ module Build
 
       Trollop.die(:reference, git_ref_desc) if options[:reference].to_s.empty?
       options[:reference] = options[:reference].to_s.strip
+
+      # 'release' build requires non DEFAULT_REF reference
+      Trollop.die(:reference, git_ref_desc) if options[:type] == "release" && options[:reference] == DEFAULT_REF
+
       self
     end
 

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -14,5 +14,27 @@ describe Build::Cli do
     it "only vsphere and ovirt" do
       expect(described_class.new.parse(%w(-o vsphere ovirt)).options[:only]).to match_array %w(vsphere ovirt)
     end
+
+    it "type (default)" do
+      expect(described_class.new.parse(%w()).options[:type]).to eq("nightly")
+    end
+
+    it "with DEFAULT_REF as reference" do
+      expect(described_class.new.parse(%w(--reference master)).options[:reference]).to eq("master")
+    end
+
+    it "release without reference" do
+      expect { described_class.new.parse(%w(--type release)) }.to raise_error(SystemExit)
+    end
+
+    it "release with DEFAULT_REF as reference" do
+      expect { described_class.new.parse(%w(--type release --reference master)) }.to raise_error(SystemExit)
+    end
+
+    it "release with non DEFAULT_REF reference" do
+      options = described_class.new.parse(%w(--type release --reference abc)).options
+      expect(options[:type]).to eq("release")
+      expect(options[:reference]).to eq("abc")
+    end
   end
 end

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -15,10 +15,15 @@ $log = Logger.new(STDOUT)
 
 cli_options = Build::Cli.parse.options
 
-puddle = nil
+puddle    = nil
+directory = "upstream"
+
 case cli_options[:type]
 when "nightly"
   build_label = cli_options[:reference]
+when "release"
+  build_label = cli_options[:reference]
+  directory   = "upstream_stable"
 when nil
   build_label = "test"
 else
@@ -86,7 +91,6 @@ hour_minute       = Time.now.strftime("%H%M")
 directory_name    = "#{year_month_day}_#{hour_minute}"
 timestamp         = "#{year_month_day}#{hour_minute}"
 
-directory       = "upstream"
 name            = "manageiq"
 
 targets = cli_options[:only].collect { |only| Build::Target.new(only) }
@@ -178,8 +182,8 @@ Dir.chdir(IMGFAC_DIR) do
   end
 end
 
-# Only update the latest symlink for a nightly
-if cli_options[:type] == "nightly"
+# Only update the latest symlink for a nightly/release
+if cli_options[:type] == "nightly" || cli_options[:type] == "release"
   symlink_name = "latest"
   link = stream_directory.join(symlink_name)
   if File.exist?(link)


### PR DESCRIPTION
'release' builds will put the images to 'upstream_stable' directory. 'nightly' will continue to put the images to 'upstream' directory.

@Fryguy @jrafanie please review.