### PR TITLE
Start memcached before anything loads rails and tries to connect.

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -58,6 +58,8 @@ unset DEBUG
 
 <%= render_partial "post/bundler" %>
 
+<%= render_partial "post/start_memcached_hack" %>
+
 # appliance_root="/opt/manageiq/manageiq-appliance" -- in post/source_setup partial
 $appliance_root/cfme-setup.sh
 

--- a/kickstarts/partials/post/start_memcached_hack.ks.erb
+++ b/kickstarts/partials/post/start_memcached_hack.ks.erb
@@ -1,0 +1,9 @@
+# For rails 5, we switched to rails' MemCacheStore [1], a subclass of rack's
+# store that tries to connect to memcached when loading rails. The prior store,
+# DalliStore, did not connect on initialize. We need to start memcached here,
+# before anything loads Rails.  See also [2].
+#
+# [1] https://github.com/ManageIQ/manageiq/pull/6704
+# [2] https://github.com/petergoldstein/dalli/pull/423
+systemctl enable memcached
+systemctl start memcached


### PR DESCRIPTION
For rails 5, we switched to rails' MemCacheStore [1], a subclass of rack's
store that tries to connect to memcached when loading rails. The prior store,
DalliStore, did not connect on initialize. We need to start memcached here,
before anything loads Rails.  See also [2].

[1] https://github.com/ManageIQ/manageiq/pull/6704
[2] petergoldstein/dalli #423