### PR TITLE
Remove service start and stop from post section

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -12,7 +12,5 @@ ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 
 # Create the journal directory to enable persistant logging
 mkdir /var/log/journal
-systemctl restart systemd-journald
 
-systemctl stop NetworkManager
 systemctl disable NetworkManager


### PR DESCRIPTION
These commands don't do anything as the post is executed
in a chroot environment.

This prevents errors in anaconda-post.log of the form:
```
  + systemctl restart systemd-journald
  Running in chroot, ignoring request.
```