### PR TITLE
Add memcached to Requires= and After= in appliance-initialize

### DIFF
--- a/kickstarts/partials/post/db_init.ks.erb
+++ b/kickstarts/partials/post/db_init.ks.erb
@@ -13,8 +13,9 @@ cat > /usr/lib/systemd/system/appliance-initialize.service <<EOF
 [Unit]
 Description=Initialize Appliance Database
 ConditionPathExists=!/var/opt/rh/rh-postgresql94/lib/pgsql/data/base
-After=evminit.service
+After=evminit.service memcached.service
 Before=evmserverd.service
+Requires=memcached.service
 [Service]
 Type=oneshot
 ExecStart=/bin/appliance-initialize.sh


### PR DESCRIPTION
This is needed because the environment rake task will fail if the memcache server is not running.

Motivated by the same issue as https://github.com/ManageIQ/manageiq-appliance-build/pull/92