### PR TITLE
Enable memcached in kickstart post

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -7,6 +7,8 @@ systemctl enable evm-watchdog
 
 systemctl enable cloud-ds-check
 
+systemctl enable memcached
+
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 


### PR DESCRIPTION
Some rake tasks require the session store to be active even before the application starts.

@jrafanie @simaishi 