### PR TITLE
Optionally allow a different branch for each repo

### DIFF
--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -27,17 +27,20 @@ module Build
 
       @options = Trollop.options(args) do
         banner "Usage: build.rb [options]"
-
-        opt :type,          type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
-        opt :reference,     git_ref_desc,   :type => :string,  :short => "r", :default => DEFAULT_REF
-        opt :local,         local_desc,     :type => :boolean, :short => "l", :default => false
-        opt :fileshare,     share_desc,     :type => :boolean, :short => "s", :default => true
-        opt :manageiq_url,  manageiq_desc,  :type => :string,  :short => "M", :default => MANAGEIQ_URL
+        opt :appliance_ref, git_ref_desc,   :type => :string,  :short => "a", :default => DEFAULT_REF
         opt :appliance_url, appliance_desc, :type => :string,  :short => "A", :default => APPLIANCE_URL
+        opt :build_ref,     git_ref_desc,   :type => :string,  :short => "b", :default => DEFAULT_REF
         opt :build_url,     build_desc,     :type => :string,  :short => "B", :default => BUILD_URL
-        opt :ssui_url,      ssui_desc,      :type => :string,  :short => "S", :default => SSUI_URL
-        opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
+        opt :reference,     git_ref_desc,   :type => :string,  :short => "r", :default => nil
+        opt :fileshare,     share_desc,     :type => :boolean, :short => "f", :default => true
+        opt :local,         local_desc,     :type => :boolean, :short => "l", :default => false
+        opt :manageiq_ref,  git_ref_desc,   :type => :string,  :short => "m", :default => DEFAULT_REF
+        opt :manageiq_url,  manageiq_desc,  :type => :string,  :short => "M", :default => MANAGEIQ_URL
         opt :only,          only_desc,      :type => :strings, :short => "o", :default => Target.default_types
+        opt :ssui_ref,      git_ref_desc,   :type => :string,  :short => "s", :default => DEFAULT_REF
+        opt :ssui_url,      ssui_desc,      :type => :string,  :short => "S", :default => SSUI_URL
+        opt :type,          type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
+        opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
       end
 
       options[:type] &&= options[:type].strip
@@ -46,11 +49,14 @@ module Build
         options[:only] = Target.supported_types
       end
 
-      Trollop.die(:reference, git_ref_desc) if options[:reference].to_s.empty?
-      options[:reference] = options[:reference].to_s.strip
+      # --reference overrides all other reference arguments
+      [:manageiq_ref, :appliance_ref, :build_ref, :ssui_ref].each do |ref|
+        options[ref] = (options[:reference] || options[ref]).to_s.strip
+      end
+      Trollop.die(:manageiq_ref, git_ref_desc) if options[:manageiq_ref].to_s.empty?
 
       # 'release' build requires non DEFAULT_REF reference
-      Trollop.die(:reference, git_ref_desc) if options[:type] == "release" && options[:reference] == DEFAULT_REF
+      Trollop.die(:manageiq_ref, git_ref_desc) if options[:type] == "release" && options[:manageiq_ref] == DEFAULT_REF
 
       self
     end

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -19,15 +19,53 @@ describe Build::Cli do
       expect(described_class.new.parse(%w()).options[:type]).to eq("nightly")
     end
 
-    it "with DEFAULT_REF as reference" do
-      expect(described_class.new.parse(%w(--reference master)).options[:reference]).to eq("master")
+    it "with a branch name for reference override" do
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:appliance_ref]).to eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:build_ref]).to     eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:manageiq_ref]).to  eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:ssui_ref]).to      eq("branch_name")
+    end
+
+    it "with a branch name for appliance reference" do
+      expect(described_class.new.parse(%w(-a branch_name)).options[:appliance_ref]).to eq("branch_name")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:build_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:manageiq_ref]).to  eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:ssui_ref]).to      eq("master")
+    end
+
+    it "with a branch name for build reference" do
+      expect(described_class.new.parse(%w(-b branch_name)).options[:appliance_ref]).to eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:build_ref]).to     eq("branch_name")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:manageiq_ref]).to  eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:ssui_ref]).to      eq("master")
+    end
+
+    it "with a branch name for manageiq reference" do
+      expect(described_class.new.parse(%w(-m branch_name)).options[:appliance_ref]).to eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:build_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:manageiq_ref]).to  eq("branch_name")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:ssui_ref]).to      eq("master")
+    end
+
+    it "with a branch name for ssui reference" do
+      expect(described_class.new.parse(%w(-s branch_name)).options[:appliance_ref]).to eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:build_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:manageiq_ref]).to  eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:ssui_ref]).to      eq("branch_name")
+    end
+
+    it "with DEFAULT_REF for reference override" do
+      expect(described_class.new.parse(%w(--reference master -a branch_name)).options[:appliance_ref]).to eq("master")
+      expect(described_class.new.parse(%w(--reference master -b branch_name)).options[:build_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(--reference master -m branch_name)).options[:manageiq_ref]).to  eq("master")
+      expect(described_class.new.parse(%w(--reference master -s branch_name)).options[:ssui_ref]).to      eq("master")
     end
 
     it "release without reference" do
       expect { described_class.new.parse(%w(--type release)) }.to raise_error(SystemExit)
     end
 
-    it "release with DEFAULT_REF as reference" do
+    it "release with DEFAULT_REF for reference" do
       expect { described_class.new.parse(%w(--type release --reference master)) }.to raise_error(SystemExit)
     end
 

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -20,15 +20,15 @@ directory = "upstream"
 
 case cli_options[:type]
 when "nightly"
-  build_label = cli_options[:reference]
+  build_label = cli_options[:manageiq_ref]
 when "release"
-  build_label = cli_options[:reference]
+  build_label = cli_options[:manageiq_ref]
   directory   = "upstream_stable"
 when nil
   build_label = "test"
 else
   puddle = cli_options[:type]
-  build_label = "#{cli_options[:type]}-#{cli_options[:reference]}"
+  build_label = "#{cli_options[:type]}-#{cli_options[:manageiq_ref]}"
 end
 
 BUILD_BASE          = Pathname.new("/build")
@@ -46,23 +46,23 @@ FILE_SERVER_BASE    = Pathname.new(ENV["BUILD_FILE_SERVER_BASE"] || ".") # Subdi
 
 if !cli_options[:local] && cli_options[:build_url]
   build_repo = cli_options[:build_url]
-  cfg_base = REFS_DIR.join(cli_options[:reference])
+  cfg_base = REFS_DIR.join(cli_options[:build_ref])
   FileUtils.mkdir_p(cfg_base)
   Dir.chdir(cfg_base) do
     unless File.exist?(".git")
       $log.info("Cloning Repo #{build_repo} to #{cfg_base} ...")
       `git clone #{build_repo} .` unless File.exist?(".git")
     end
-    $log.info("Checking out reference #{cli_options[:reference]} from repo #{build_repo} ...")
+    $log.info("Checking out reference #{cli_options[:build_ref]} from repo #{build_repo} ...")
     `git reset --hard`                                    # Drop any local changes
     `git clean -dxf`                                      # Clean up any local untracked changes
-    `git checkout #{cli_options[:reference]}`             # Checkout existing branch
+    `git checkout #{cli_options[:build_ref]}`             # Checkout existing branch
     `git fetch origin`                                    # Get origin updates
-    `git reset --hard origin/#{cli_options[:reference]}`  # Reset the branch to the origin
+    `git reset --hard origin/#{cli_options[:build_ref]}`  # Reset the branch to the origin
   end
 
   unless File.exist?(cfg_base)
-    $log.error("Could not checkout repo #{build_repo} for reference #{cli_options[:reference]}")
+    $log.error("Could not checkout repo #{build_repo} for reference #{cli_options[:build_ref]}")
     exit 1
   end
 else
@@ -95,9 +95,9 @@ name            = "manageiq"
 
 targets = cli_options[:only].collect { |only| Build::Target.new(only) }
 
-manageiq_checkout  = Build::GitCheckout.new(:remote => cli_options[:manageiq_url],  :ref => cli_options[:reference])
-appliance_checkout = Build::GitCheckout.new(:remote => cli_options[:appliance_url], :ref => cli_options[:reference])
-ssui_checkout      = Build::GitCheckout.new(:remote => cli_options[:ssui_url],      :ref => cli_options[:reference])
+manageiq_checkout  = Build::GitCheckout.new(:remote => cli_options[:manageiq_url],  :ref => cli_options[:manageiq_ref])
+appliance_checkout = Build::GitCheckout.new(:remote => cli_options[:appliance_url], :ref => cli_options[:appliance_ref])
+ssui_checkout      = Build::GitCheckout.new(:remote => cli_options[:ssui_url],      :ref => cli_options[:ssui_ref])
 ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:only], puddle, manageiq_checkout, appliance_checkout, ssui_checkout)
 ks_gen.run
 


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-appliance-build/issues/95

This PR will make building development image to test proposed changes simpler.
This will be done by adding optional command line arguments where specific branch names
can be specified for each of the repos.

No default behavior is changing.