### PR TITLE
Build hyperv by default

### DIFF
--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,7 +4,7 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv)
     end
 
     it "all" do

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -30,7 +30,7 @@ describe Build::Target do
   end
 
   it ".default_types" do
-    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere)
+    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv)
   end
 
   it "#to_s" do

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -16,7 +16,7 @@ module Build
     end
 
     def self.default_types
-      supported_types - ["hyperv"]
+      supported_types
     end
 
     def initialize(name)


### PR DESCRIPTION
The instruction has been updated to put newer version of qemu-img to get reasonable size .vhd image (thanks @abellotti )