### PR TITLE
Install cifs-utils package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -20,6 +20,7 @@ readline-devel
 zlib-devel
 
 chrony
+cifs-utils
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem
 lshw                             # From epel


### PR DESCRIPTION
This will allow us to mount Samba shares for database backups

http://talk.manageiq.org/t/schedule-db-backup-samba-issue/1209
https://bugzilla.redhat.com/show_bug.cgi?id=1313958

@gtanzillo @jvlcek 