### PR TITLE
Make the root filesystem a size that makes sense

### DIFF
--- a/kickstarts/partials/main/disk_layout.ks.erb
+++ b/kickstarts/partials/main/disk_layout.ks.erb
@@ -7,7 +7,7 @@ part /boot            --ondrive=vda                     --size=512   --fstype=xf
 part /var/www/miq_tmp --ondrive=vda                     --size=10240 --fstype=xfs --fsoptions="rw,noatime,nobarrier"
 
 volgroup vg_system    --pesize=4096 pv.1
-logvol /              --name=lv_os             --vgname=vg_system --size=4680 --fstype=xfs
+logvol /              --name=lv_os             --vgname=vg_system --size=4608 --fstype=xfs
 logvol /var           --name=lv_var            --vgname=vg_system --size=2048 --fstype=xfs
 logvol /var/log       --name=lv_var_log        --vgname=vg_system --size=1024 --fstype=xfs
 logvol /var/log/audit --name=lv_var_log_audit  --vgname=vg_system --size=512  --fstype=xfs


### PR DESCRIPTION
I think 4680 was a typo of 4608 (4.5 GiB)

@jrafanie Because it was bothering me and @simaishi 