### PR TITLE
Use the fedorainfracloud URLs to download the .repo files

### DIFF
--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -3,7 +3,7 @@
 # Please also add to "build time repos" main/repos partial
 
 pushd /etc/yum.repos.d/
-  wget https://copr.fedoraproject.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
-  wget https://copr-fe.cloud.fedoraproject.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo
+  wget https://copr.fedorainfracloud.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
+  wget https://copr.fedorainfracloud.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo
   wget https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
 popd


### PR DESCRIPTION
Previously we were getting redirected for the abellott repo and getting a certificate error on the scl copr repo.

This meant that we would not have the copr postgres repo enabled on the appliance.

We were getting the following output in `anaconda-post.log`:
For the manageiq-scl (abellott) repo:
```plain
+ wget https://copr.fedoraproject.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
--2016-03-08 20:29:27--  https://copr.fedoraproject.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
Resolving copr.fedoraproject.org (copr.fedoraproject.org)... 140.211.169.196, 66.35.62.162, 209.132.181.16, ...
Connecting to copr.fedoraproject.org (copr.fedoraproject.org)|140.211.169.196|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://copr.fedorainfracloud.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo [following]
--2016-03-08 20:29:27--  https://copr.fedorainfracloud.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
Resolving copr.fedorainfracloud.org (copr.fedorainfracloud.org)... 209.132.184.54
Connecting to copr.fedorainfracloud.org (copr.fedorainfracloud.org)|209.132.184.54|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 322 [text/plain]
Saving to: 'abellott-manageiq-scl-epel-7.repo'

     0K                                                       100% 20.0M=0s

2016-03-08 20:29:28 (20.0 MB/s) - 'abellott-manageiq-scl-epel-7.repo' saved [322/322]
```

And for the scl copr repo:
```plain
+ wget https://copr-fe.cloud.fedoraproject.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo
--2016-03-08 20:29:28--  https://copr-fe.cloud.fedoraproject.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo
Resolving copr-fe.cloud.fedoraproject.org (copr-fe.cloud.fedoraproject.org)... 209.132.184.54
Connecting to copr-fe.cloud.fedoraproject.org (copr-fe.cloud.fedoraproject.org)|209.132.184.54|:443... connected.
ERROR: no certificate subject alternative name matches
        requested host name 'copr-fe.cloud.fedoraproject.org'.
To connect to copr-fe.cloud.fedoraproject.org insecurely, use `--no-check-certificate'.
```

@abellotti @jrafanie 