### PR TITLE
Kickstart file related changes needed to create an appliance for Azure

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -10,7 +10,7 @@ cdrom
 
 lang en_US.UTF-8
 keyboard us
-network --onboot yes --device eth0 --bootproto dhcp
+network --onboot yes --device eth0 --bootproto dhcp<%= " --noipv6" if @target == "azure" || @target == "openstack" %>
 rootpw  --iscrypted $1$DZprqvCu$mhqFBjfLTH/PVvZIompVP/
 
 authconfig --enableshadow --passalgo=sha512
@@ -89,7 +89,9 @@ echo "" >> /etc/ssh/sshd_config
 # Let's rebuild the ramfs with with base scsi drivers we need
 kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"
-/sbin/dracut --force --add-drivers "mptbase mptscsih mptspi<%= " hv_storvsc hid_hyperv hv_netvsc hv_vmbus" if @target == "hyperv" %>" $ramfsfile $kversion
+/sbin/dracut --force --add-drivers "mptbase mptscsih mptspi<%= " hv_storvsc hid_hyperv hv_netvsc hv_vmbus" if @target == "hyperv" || @target == "azure" %>" $ramfsfile $kversion
+
+<%= render_partial "post/azure" if @target == "azure" %>
 
 chvt 1
 %end

--- a/kickstarts/partials/main/bootloader.ks.erb
+++ b/kickstarts/partials/main/bootloader.ks.erb
@@ -1,1 +1,7 @@
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0<%= " console=tty0 console=ttyS0,115200n8" if @target == "openstack" %>"
+<% if @target == "openstack" %>
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
+<% elsif @target == "azure" %>
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+<% else %>
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0"
+<% end %>

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -72,7 +72,9 @@ openldap-clients
 # External Authentication - SAML
 mod_auth_mellon
 
+<% unless @target == "azure" %>
 cloud-init
+<% end %>
 
 wmi
 
@@ -83,4 +85,6 @@ npm
 ovirt-guest-agent
 <% elsif @target == "vsphere" %>
 open-vm-tools
+<% elsif @target == "azure" %>
+WALinuxAgent
 <% end %>

--- a/kickstarts/partials/post/azure.ks.erb
+++ b/kickstarts/partials/post/azure.ks.erb
@@ -1,0 +1,10 @@
+# Configure swap in WALinuxAgent
+sed -i 's/^\(ResourceDisk\.EnableSwap\)=[Nn]$/\1=y/g' /etc/waagent.conf
+sed -i 's/^\(ResourceDisk\.SwapSizeMB\)=[0-9]*$/\1=10240/g' /etc/waagent.conf
+
+# Enable SSH keepalive
+sed -i 's/^#\(ClientAliveInterval\).*$/\1 180/g' /etc/ssh/sshd_config
+
+systemctl enable waagent.service
+sed -i 's/Provisioning\.DeleteRootPassword=y/Provisioning\.DeleteRootPassword=n/' /etc/waagent.conf
+waagent -force -deprovision

--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -5,7 +5,9 @@ systemctl enable miqvmstat
 systemctl enable evminit
 systemctl enable evm-watchdog
 
+<% unless @target == "azure" %>
 systemctl enable cloud-ds-check
+<% end %>
 
 systemctl enable memcached
 


### PR DESCRIPTION
This PR contains kickstart related changes for Azure appliance (disk layout will be revisited/modified later).

- No ipv6
- Modify boot loader options (output to serial port, rootdelay)
- Add hyperv drivers
- No cloud-init
- Install/configure WALinuxAgent (Swap space, deprovision, SSH ClientAliveInterval)

The other changes needed for scripts are not yet completed. Putting this PR now, so downstream build can take advantage of this change, as per discussion with @Fryguy 