### PR TITLE
Adding support for building gce appliance

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -10,7 +10,7 @@ cdrom
 
 lang en_US.UTF-8
 keyboard us
-network --onboot yes --device eth0 --bootproto dhcp<%= " --noipv6" if @target == "azure" || @target == "openstack" %>
+<%= render_partial "main/network" %>
 rootpw  --iscrypted $1$DZprqvCu$mhqFBjfLTH/PVvZIompVP/
 
 authconfig --enableshadow --passalgo=sha512
@@ -92,6 +92,7 @@ ramfsfile="/boot/initramfs-$kversion.img"
 /sbin/dracut --force --add-drivers "mptbase mptscsih mptspi<%= " hv_storvsc hid_hyperv hv_netvsc hv_vmbus" if @target == "hyperv" || @target == "azure" %>" $ramfsfile $kversion
 
 <%= render_partial "post/azure" if @target == "azure" %>
+<%= render_partial "post/gce" if @target == "gce" %>
 
 chvt 1
 %end

--- a/kickstarts/partials/main/bootloader.ks.erb
+++ b/kickstarts/partials/main/bootloader.ks.erb
@@ -2,6 +2,8 @@
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
 <% elsif @target == "azure" %>
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+<% elsif @target == "gce" %>
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0,38400n8"
 <% else %>
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0"
 <% end %>

--- a/kickstarts/partials/main/network.ks.erb
+++ b/kickstarts/partials/main/network.ks.erb
@@ -1,0 +1,7 @@
+<% if @target == "openstack" || @target == "azure" %>
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+<% elsif @target == "gce" %>
+network --onboot yes --device eth0 --bootproto dhcp --noipv6 --mtu=1460
+<% else %>
+network --onboot yes --device eth0 --bootproto dhcp
+<% end %>

--- a/kickstarts/partials/post/gce.ks.erb
+++ b/kickstarts/partials/post/gce.ks.erb
@@ -1,0 +1,20 @@
+# GCE Kernel security settings
+cat >> /etc/sysctl.d/11-gce-network-security.conf << EOF
+net.ipv4.tcp_syncookies = 1
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.secure_redirects = 1
+net.ipv4.conf.default.secure_redirects = 1
+net.ipv4.ip_forward = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv4.conf.default.send_redirects = 0
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+net.ipv4.tcp_rfc1337 = 1
+kernel.randomize_va_space = 2
+EOF
+
+# Enable SSH keepalive
+sed -i 's/^#\(ClientAliveInterval\).*$/\1 420/g' /etc/ssh/sshd_config


### PR DESCRIPTION
Log kernel and syslog messages to /dev/ttyS0, so you can debug with gcloud compute instances get-serial-port-output. 