### PR TITLE
Direct output from post to both stdout and tty3

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -38,8 +38,10 @@ reboot
 %end
 
 %post --log=/root/anaconda-post.log
+(
+# Redirect stdin to be /dev/tty3
+exec < /dev/tty3
 
-exec < /dev/tty3 > /dev/tty3
 chvt 3
 set -x
 
@@ -94,4 +96,5 @@ ramfsfile="/boot/initramfs-$kversion.img"
 <%= render_partial "post/azure" if @target == "azure" %>
 
 chvt 1
+) 2>&1 | tee /dev/tty3
 %end


### PR DESCRIPTION
This will allow us to see the output from commands run in the `%post` section in `anaconda-post.log`.

Previously they were being sent to `/dev/tty3` and not stdout so they would not be seen by the `--log` directive.

@abellotti This is the only thing I could get to work outside of removing the `/dev/tty3` stuff entirely.
It's not pretty, but it will be much easier to diagnose build failures this way.

@JPrause FYI