### PR TITLE
Expand misleading comment on npm package include

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -81,7 +81,7 @@ cloud-init
 
 wmi
 
-# Self Service UI
+# bower; Self Service UI (in devel mode)
 npm
 
 <% if @target == "ovirt" %>


### PR DESCRIPTION
npm is no longer needed solely for self service, bower also depends on it

Closes #117 