### PR TITLE
ui_compile - install (newer) npm via npm

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,4 +1,4 @@
-npm install gulp bower -g
+npm install gulp bower npm -g
 
 pushd /var/www/miq/vmdb
   bower -F --allow-root install


### PR DESCRIPTION
Because the version of npm available via RPM is only 1.3.6,
and some of the self-service dependencies need npm 3.*,
we'll use the RPM-installed npm to install a current npm version.

Should address https://github.com/ManageIQ/manageiq/issues/8023 and https://github.com/ManageIQ/manageiq/issues/7801