### PR TITLE
Add glusterfs-fuse package.

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -86,6 +86,7 @@ npm
 
 <% if @target == "ovirt" %>
 ovirt-guest-agent
+glusterfs-fuse
 <% elsif @target == "vsphere" %>
 open-vm-tools
 <% elsif @target == "azure" %>


### PR DESCRIPTION
Add the glusterfs-fuse package in order to support SSA for Gluster
based VMs on RHEV.