### PR TITLE
Run `bundle install` under self_service too

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -64,6 +64,7 @@ export RAILS_USE_MEMORY_STORE="true"
 
 <%= render_partial "post/bundler" %>
 
+# needs to run *after* post/bundler
 <%= render_partial "post/ui_compile" %>
 
 # appliance_root="/opt/manageiq/manageiq-appliance" -- in post/source_setup partial

--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -11,3 +11,7 @@ gem install bundler -v ">=1.8.4"
 pushd /var/www/miq/vmdb
   bundle install
 popd
+
+pushd /opt/manageiq/manageiq-ui-self_service
+  bundle install
+popd

--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -13,5 +13,6 @@ pushd /var/www/miq/vmdb
 popd
 
 pushd /opt/manageiq/manageiq-ui-self_service
-  bundle install
+  # overriding exported BUNDLE_GEMFILE
+  bundle install --gemfile Gemfile
 popd

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,4 +1,5 @@
-npm install gulp bower npm -g
+npm install -g npm
+npm install -g gulp bower
 
 pushd /var/www/miq/vmdb
   bower -F --allow-root install


### PR DESCRIPTION
To prevent `Could not find sass-3.4.21 in any of the sources (Bundler::GemNotFound)` when running `gulp build`.

We do technically run `bundle install` from within `npm install`, but it seems it's run in a clean environment and doesn't work reliably, this should.

https://bugzilla.redhat.com/show_bug.cgi?id=1329761

@simaishi could you verify that this fixes the problem please? There should be no more GemNotFound in the log, *and* `/var/www/miq/vmdb/public/self_service/styles/app-*.css` should be about 12 kB (instead of almost empty).