### PR TITLE
Change upload directory to allow nightly from different branches

### DIFF
--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -6,7 +6,9 @@
 # fileshare: true
 #
 
-source '/build/bin/shared_functions.sh'
+BUILD_DIR="$(dirname "$(readlink -f "$0")")/.."
+
+source "${BUILD_DIR}/bin/shared_functions.sh"
 stop_on_existing_build
 
 LOG_DIR=/build/logs
@@ -26,9 +28,9 @@ if [ "${1}" = "--fg" ]
 then
   echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
 
-  time ruby /build/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
+  time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
 else
-  nohup time ruby /build/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
+  nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
 
   echo "Nightly Build kicked off, Log @ ${LOG_FILE} ..."
 fi

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -13,7 +13,7 @@ LOG_DIR=/build/logs
 mkdir -p ${LOG_DIR}
 
 DATE_STAMP=`date +"%Y%m%d_%T"`
-LOG_FILE="${LOG_DIR}/upstream_${DATE_STAMP}.log"
+LOG_FILE="${LOG_DIR}/master_${DATE_STAMP}.log"
 BUILD_OPTIONS="--type nightly --upload"
 
 if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -10,5 +10,6 @@ if [[ $# != 1 ]]; then
 fi
 
 log_file="/build/logs/${1}.log"
-nohup time ruby /build/scripts/vmbuild.rb --type release --upload --reference $1 > $log_file 2>&1 &
+
+nohup time ruby /build/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
 echo "${1} release build kicked off, see log @ $log_file ..."

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-source '/build/bin/shared_functions.sh'
+BUILD_DIR="$(dirname "$(readlink -f "$0")")/.."
+
+source "${BUILD_DIR}/bin/shared_functions.sh"
 stop_on_existing_build
 
 if [[ $# != 1 ]]; then
@@ -10,6 +12,5 @@ if [[ $# != 1 ]]; then
 fi
 
 log_file="/build/logs/${1}.log"
-
-nohup time ruby /build/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
+nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
 echo "${1} release build kicked off, see log @ $log_file ..."

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -17,6 +17,7 @@ module Build
       git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"
       type_desc      = "build type: nightly, release, test, a named yum repository"
       local_desc     = "Use local config and kickstart for build"
+      dir_desc       = "Directory to copy builds to"
       share_desc     = "Copy builds to file share"
       manageiq_desc  = "Repo URL containing the ManageIQ code"
       appliance_desc = "Repo URL containing appliance scripts and configs(COPY/LINK/TEMPLATE)"
@@ -32,6 +33,7 @@ module Build
         opt :build_ref,     git_ref_desc,   :type => :string,  :short => "b", :default => DEFAULT_REF
         opt :build_url,     build_desc,     :type => :string,  :short => "B", :default => BUILD_URL
         opt :reference,     git_ref_desc,   :type => :string,  :short => "r", :default => nil
+        opt :copy_dir,      dir_desc,       :type => :string,  :short => "d", :default => DEFAULT_REF
         opt :fileshare,     share_desc,     :type => :boolean, :short => "f", :default => true
         opt :local,         local_desc,     :type => :boolean, :short => "l", :default => false
         opt :manageiq_ref,  git_ref_desc,   :type => :string,  :short => "m", :default => DEFAULT_REF

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -16,14 +16,13 @@ $log = Logger.new(STDOUT)
 cli_options = Build::Cli.parse.options
 
 puddle    = nil
-directory = "upstream"
+directory = cli_options[:copy_dir]
 
 case cli_options[:type]
 when "nightly"
   build_label = cli_options[:manageiq_ref]
 when "release"
   build_label = cli_options[:manageiq_ref]
-  directory   = "upstream_stable"
 when nil
   build_label = "test"
 else
@@ -182,7 +181,7 @@ end
 
 # Only update the latest symlink for a nightly/release
 if cli_options[:type] == "nightly" || cli_options[:type] == "release"
-  symlink_name = "latest"
+  symlink_name = cli_options[:type] == "nightly" ? "latest" : "stable"
   link = stream_directory.join(symlink_name)
   if File.exist?(link)
     raise "#{link} is not a symlink!" unless File.symlink?(link)


### PR DESCRIPTION
Added an option to specify the image upload directory, to allow nightly/release builds from different branches.

This PR will change where the images will be uploaded to and how symlinks are created.  This is aligned with the internal file share structure change @bdunne is working on.

Currently:
- **upstream** dir for any **nightly** build, **latest** symlink for the latest nightly build
- **upstream_stable** dir for any **release** build, **latest** symlink for the latest release build

With this change:
- **master** dir for **nightly** build for **master** branch, **latest** symlink for the latest nightly build
- **\<branch>** dir for **nightly** and **release** builds for **\<branch>**, **latest** symlink for the latest nightly build and **stable** symlink for the latest **release** build
- `--copy-dir <directory name>` to specify upload directory for any build

Once this is merged, fileshare mount on kegerator needs to be updated.