### PR TITLE
Add azure image build

### DIFF
--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -1,0 +1,16 @@
+<template>
+  <name>CentOS-7.2</name>
+  <os>
+    <rootpw>ozrootpw</rootpw>
+    <name>CentOS-7</name>
+    <version>2</version>
+    <arch>x86_64</arch>
+    <install type="iso">
+      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1511.iso</iso>
+    </install>
+  </os>
+  <description>CentOS72 TDL meant to be used with custom kickstart for manageiq.</description>
+  <disk>
+    <size>35G</size>
+  </disk>
+</template>

--- a/kickstarts/partials/main/disk_layout.ks.erb
+++ b/kickstarts/partials/main/disk_layout.ks.erb
@@ -2,15 +2,17 @@
 zerombr
 clearpart       --all --drives=vda
 
-part pv.1             --ondrive=vda                     --size=16384
+part pv.1             --ondrive=vda                     --size=<%= @target == "azure" ? "11264" : "16384" %>
 part /boot            --ondrive=vda                     --size=512   --fstype=xfs
 part /var/www/miq_tmp --ondrive=vda                     --size=10240 --fstype=xfs --fsoptions="rw,noatime,nobarrier"
 
 volgroup vg_system    --pesize=4096 pv.1
-logvol /              --name=lv_os             --vgname=vg_system --size=4608 --fstype=xfs
+logvol /              --name=lv_os             --vgname=vg_system --size=4608 --fstype=xfs<%= " --grow" if @target == "azure" %>
 logvol /var           --name=lv_var            --vgname=vg_system --size=2048 --fstype=xfs
 logvol /var/log       --name=lv_var_log        --vgname=vg_system --size=1024 --fstype=xfs
 logvol /var/log/audit --name=lv_var_log_audit  --vgname=vg_system --size=512  --fstype=xfs
 logvol /tmp           --name=lv_tmp            --vgname=vg_system --size=1024 --fstype=xfs
 logvol /home          --name=lv_home           --vgname=vg_system --size=1024 --fstype=xfs
+<% unless @target == "azure" %>
 logvol swap           --name=lv_swap           --vgname=vg_system --size=4096 --grow
+<% end %>

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,11 +4,11 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure)
     end
 
     it "all" do
-      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv)
+      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure)
     end
 
     it "only vsphere and ovirt" do

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -26,11 +26,11 @@ describe Build::Target do
   end
 
   it ".supported_types" do
-    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv)
+    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure)
   end
 
   it ".default_types" do
-    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv)
+    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure)
   end
 
   it "#to_s" do

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -6,7 +6,8 @@ module Build
       'vsphere'   => ImagefactoryMetadata.new('vsphere', 'ova'),
       'ovirt'     => ImagefactoryMetadata.new('rhevm', 'ova'),
       'openstack' => ImagefactoryMetadata.new('openstack-kvm', 'qc2'),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', 'vhd')
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', 'vhd'),
+      'azure'     => ImagefactoryMetadata.new('azure', 'vhd')
     }
 
     attr_reader :name


### PR DESCRIPTION
The remaining item is to change disk_layout.

Currently, applinaces have ~6GB swap space on the 40GB disk (--size=4096 --grow).  When a VM is created in Azure, Azure gives an additional disk that can be used to store temporary data at no extra cost (the primary use of this disk is cache/swap). So for Azure, that's where swap will be created:

https://github.com/ManageIQ/manageiq-appliance-build/blob/master/kickstarts/partials/post/azure.ks.erb#L3

(set swap to be 10GB for now)

We have a few options for that ~6GB not needed for Azure:

1. Reduce the overall disk size by ~6GB
1. Keep the disk size as is, and increase size on different volume(s) (which one?)
1. Leave everything as is, which makes the swap to be 16GB
1. Don't create swap on temporary storage and make it consistent with other appliances

My preference is 1 or 2, but looking for suggestion... @carbonin @abellotti ?