### PR TITLE
Use ruby 2.2.5 for appliance builds.

### DIFF
--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -8,10 +8,10 @@ make install
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-/usr/local/bin/ruby-install ruby 2.2.4 -- --disable-install-doc --enable-shared
+/usr/local/bin/ruby-install ruby 2.2.5 -- --disable-install-doc --enable-shared
 
 # Add the ruby binaries path to the PATH so we can find bundle and friends:
-ruby_bin_path=(/opt/rubies/ruby-2.2.4/bin)
+ruby_bin_path=(/opt/rubies/ruby-2.2.5/bin)
 echo "export PATH=\$PATH:$ruby_bin_path" >> /etc/default/evm
 
 cat /etc/default/evm


### PR DESCRIPTION
cc @bdunne @Fryguy

I'm thinking darga should go out with the latest 2.2.x ruby.