### PR TITLE
Add doc builds to nightly build

### DIFF
--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -16,6 +16,7 @@ mkdir -p ${LOG_DIR}
 
 DATE_STAMP=`date +"%Y%m%d_%T"`
 LOG_FILE="${LOG_DIR}/master_${DATE_STAMP}.log"
+DOCS_LOG_FILE="${LOG_DIR}/master_${DATE_STAMP}_docs.log"
 BUILD_OPTIONS="--type nightly --upload"
 
 if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]
@@ -29,8 +30,10 @@ then
   echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
 
   time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
+  time ruby ${BUILD_DIR}/scripts/docbuild.rb 2>&1 | tee ${DOCS_LOG_FILE}
 else
   nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
+  nohup time ruby ${BUILD_DIR}/scripts/docbuild.rb >${DOCS_LOG_FILE} 2>&1 &
 
   echo "Nightly Build kicked off, Log @ ${LOG_FILE} ..."
 fi

--- a/scripts/docbuild.rb
+++ b/scripts/docbuild.rb
@@ -1,0 +1,34 @@
+require 'logger'
+require 'pathname'
+require 'fileutils'
+
+$log = Logger.new(STDOUT)
+
+BUILD_BASE     = Pathname.new("/build")
+FILESHARE_DIR  = BUILD_BASE.join("fileshare")
+
+DOCS_BRANCH    = "master"
+DOCS_REPO      = BUILD_BASE.join("manageiq_docs")
+DOCS_PACKAGE   = DOCS_REPO.join("_package/community", DOCS_BRANCH)
+DOCS_FILESHARE = FILESHARE_DIR.join(DOCS_BRANCH, "latest-docs")
+
+def execute(cmd)
+  exit $?.exitstatus unless system(cmd)
+end
+
+$log.info("Packaging docs...")
+FileUtils.rm_rf DOCS_REPO
+Dir.chdir(BUILD_BASE) do
+  execute("git clone https://github.com/ManageIQ/manageiq_docs")
+  Dir.chdir("manageiq_docs") do
+    execute("git checkout #{DOCS_BRANCH}")
+    execute("bundle install")
+    execute("bundle exec ascii_binder package")
+  end
+end
+$log.info("Packaging docs...Complete")
+
+$log.info("Copying docs to fileshare...")
+FileUtils.rm_rf DOCS_FILESHARE
+FileUtils.cp_r(DOCS_PACKAGE, DOCS_FILESHARE)
+$log.info("Copying docs to fileshare...Complete")


### PR DESCRIPTION
This builds the docs on a nightly basis with some current restrictions...

- Only master branch
- Only the lastest (i.e. not docs per timestamp)
- Doesn't upload to the website yet, only to the fileshare