### PR TITLE
Use build type to determine nightly or release

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -2,14 +2,15 @@ require 'fog'
 
 module Build
   class Uploader
-    attr_reader :directory
+    attr_reader :directory, :type
 
-    def self.upload(directory)
-      new(directory).run
+    def self.upload(directory, type)
+      new(directory, type).run
     end
 
-    def initialize(directory)
+    def initialize(directory, type)
       @directory = directory
+      @type      = type
     end
 
     def service
@@ -50,10 +51,10 @@ module Build
     #                   manageiq-ovirt-master-20140613-8d9d1b8.ova
     def uploaded_filename(appliance_name)
       filename =
-        if appliance_name.include?("-master-")
-          nightly_filename(appliance_name)
-        else
+        if type == "release"
           release_filename(appliance_name)
+        else
+          nightly_filename(appliance_name)
         end
       File.basename(filename)
     end

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -200,5 +200,5 @@ if cli_options[:type] == "nightly" || cli_options[:type] == "release"
     $log.info `ssh #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER} "#{ssh_cmd}"`
   end
 
-  Build::Uploader.upload(destination_directory) if cli_options[:upload]
+  Build::Uploader.upload(destination_directory, cli_options[:type]) if cli_options[:upload]
 end


### PR DESCRIPTION
Now we have 'darga' nightly, we can't rely on the word 'master' being in the file name to determine if it's a nightly build or not.

@abellotti @Fryguy please review