### PR TITLE
docbuild.rb needs to create latest-docs/master/ in target for ascii_binder.

### DIFF
--- a/scripts/docbuild.rb
+++ b/scripts/docbuild.rb
@@ -30,5 +30,6 @@ $log.info("Packaging docs...Complete")
 
 $log.info("Copying docs to fileshare...")
 FileUtils.rm_rf DOCS_FILESHARE
+FileUtils.mkdir_p DOCS_FILESHARE
 FileUtils.cp_r(DOCS_PACKAGE, DOCS_FILESHARE)
 $log.info("Copying docs to fileshare...Complete")


### PR DESCRIPTION
ascii_binder references the stylesheet via ../../master/ so we need the latest-docs to include the master/ subdirectory.
