### PR TITLE
Disable password authentication for Azure

### DIFF
--- a/kickstarts/partials/post/azure.ks.erb
+++ b/kickstarts/partials/post/azure.ks.erb
@@ -2,9 +2,15 @@
 sed -i 's/^\(ResourceDisk\.EnableSwap\)=[Nn]$/\1=y/g' /etc/waagent.conf
 sed -i 's/^\(ResourceDisk\.SwapSizeMB\)=[0-9]*$/\1=10240/g' /etc/waagent.conf
 
-# Enable SSH keepalive
+# sshd configuration
 sed -i 's/^#\(ClientAliveInterval\).*$/\1 180/g' /etc/ssh/sshd_config
+sed -i 's/^#\(PermitRootLogin\).*$/\1 no/g' /etc/ssh/sshd_config
+sed -i 's/^\(PasswordAuthentication\).*$/\1 no/g' /etc/ssh/sshd_config
+sed -i 's/^\(X11Forwarding\).*$/\1 no/g' /etc/ssh/sshd_config
 
 systemctl enable waagent.service
 sed -i 's/Provisioning\.DeleteRootPassword=y/Provisioning\.DeleteRootPassword=n/' /etc/waagent.conf
 waagent -force -deprovision
+
+# Lock root account
+usermod -L root


### PR DESCRIPTION
With this change, the only way allowed to login to appliance will be using ssh key.

https://bugzilla.redhat.com/show_bug.cgi?id=1339677