### PR TITLE
Use the centos.org repo for scl packages

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -5,7 +5,7 @@ repo --name=extras  --baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
 repo --name=epel    --baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
 
 # repos to install packages not found in the os
-repo --name=rh-postgresql94_copr --baseurl=https://copr-be.cloud.fedoraproject.org/results/rhscl/rh-postgresql94/epel-7-x86_64/
+repo --name=centos-scl --baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
 repo --name=pglogical-scl --baseurl=https://copr-be.cloud.fedoraproject.org/results/ncarboni/pglogical-SCL/epel-7-x86_64/
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-compute-el7-x86_64/

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -1,4 +1,5 @@
 epel-release       # http://dl.fedoraproject.org/pub/epel/7/x86_64/epel-release-7-5.noarch.rpm
+centos-release-scl-rh
 
 createrepo
 freeipmi

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -4,7 +4,6 @@
 
 pushd /etc/yum.repos.d/
   wget https://copr.fedorainfracloud.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
-  wget https://copr.fedorainfracloud.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo
   wget https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
 popd
 


### PR DESCRIPTION
This repo seems to be updated more frequently than the copr repo and contains more recent packages.

This will also allow us to pull PostgreSQL 9.5, which the other repo did not have.