### PR TITLE
Clean the rails log directory in the kickstart post

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -99,6 +99,9 @@ ramfsfile="/boot/initramfs-$kversion.img"
 # make sure there is a new line at the end of sshd_config
 echo "" >> /etc/ssh/sshd_config
 
+# Clean the logs
+rm -rf "$vmdb_root/log/*"
+
 chvt 1
 ) 2>&1 | tee /dev/tty3
 %end


### PR DESCRIPTION
Some things that are done during the build process have the potential to print to the logs.
None of this should be present when the machine is deployed for the first time.

https://bugzilla.redhat.com/show_bug.cgi?id=1286793