### PR TITLE
Explicitly include lvm2 package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -26,6 +26,7 @@ cmake                            # For rugged gem
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem
 lshw                             # From epel
+lvm2
 memcached
 mod_ssl
 nmap-ncat


### PR DESCRIPTION
We require lvm2 to be installed when initializing the database so it should be explicitly included in the kickstart.

https://bugzilla.redhat.com/show_bug.cgi?id=1343007