### PR TITLE
Upgrade ruby 2.2.5 to 2.3.1

### DIFF
--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -8,10 +8,10 @@ make install
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-/usr/local/bin/ruby-install ruby 2.2.5 -- --disable-install-doc --enable-shared
+/usr/local/bin/ruby-install ruby 2.3.1 -- --disable-install-doc --enable-shared
 
 # Add the ruby binaries path to the PATH so we can find bundle and friends:
-ruby_bin_path=(/opt/rubies/ruby-2.2.5/bin)
+ruby_bin_path=(/opt/rubies/ruby-2.3.1/bin)
 echo "export PATH=\$PATH:$ruby_bin_path" >> /etc/default/evm
 
 cat /etc/default/evm


### PR DESCRIPTION
Purpose or Intent
-----------------

Update appliances to 2.3.1.

Ruby 2.3.1 is the latest stable release of ruby and is mostly compatible with 2.2.5 but offers some new features such:

* frozen string literals
* lonely `&.` operator (safe navigation operator, similar to Hash#fetch_path)
* did_you_mean gem for useful errors
* indented heredoc
* Clearer ArgumentError message:
```
2.2.5: wrong number of arguments (0 for 1..3)
2.3.1: wrong number of arguments (given 0, expected 1..3)
```

* more, see below

Links
-----
 * [summary of ruby 2.3.1 changes](https://github.com/ruby/spec/issues/175)

We can start using ruby 2.3.1 before or after https://github.com/ManageIQ/manageiq/pull/8488 is merged.

Related:
https://github.com/ManageIQ/manageiq/issues/9829