### PR TITLE
Add libcurl-devel, needed by curb

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -23,6 +23,7 @@ zlib-devel
 chrony
 cifs-utils
 cmake                            # For rugged gem
+libcurl-devel                    # For curb gem
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem
 lshw                             # From epel


### PR DESCRIPTION
`libcurl-devel` is needed by `curb` gem which is a dependency of `ovirt-engine-sdk` added in https://github.com/ManageIQ/manageiq/pull/9521

Fixes https://github.com/ManageIQ/manageiq/issues/10234