### PR TITLE
Add support for building Vagrant appliances.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 /pkg
 /productization
-kickstarts/generated/base.ks
-kickstarts/generated/*.json
-kickstarts/generated/*.cfg
+kickstarts/generated/*.ks
 scripts/Gemfile.dev.rb

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Below are instructions on installing and configuring a virtual machine to genera
 
 ## Setup Imagefactory:
 
-  * Clone imagefactory as /build/imagefactory
+  * Clone imagefactory as /build/imagefactory (requires version 1.1.9-3 or
+    later for command line parameter passing and hyperv target support):
 
     ```
     cd /build

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Below are instructions on installing and configuring a virtual machine to genera
     # scripts/imagefactory_dev_setup.sh
     ```
 
+  * Note that there's a bug in imagefactory where it doesn't install the
+    HyperV plugin. Until that is fixed, use the following command to install
+    it.
+
+    # ln -s /build/imagefactory/imagefactory_plugins/HyperV/HyperV.info /etc/imagefactory/plugins.d
+
 ## Setup for vSphere plugin.
 
   * Install dependencies:

--- a/config/base.json
+++ b/config/base.json
@@ -1,0 +1,3 @@
+{
+  "generate_icicle": false
+}

--- a/config/imagefactory.conf
+++ b/config/imagefactory.conf
@@ -5,6 +5,8 @@
   "no_oauth": 0,
   "imgdir": "/build/images",
   "ec2_ami_type": "ebs",
+  "rhevm_image_format": "qcow2",
+  "openstack_image_format": "qcow2",
   "clients": {
     "mock-key": "mock-secret"
     },

--- a/config/imagefactory.conf
+++ b/config/imagefactory.conf
@@ -5,8 +5,6 @@
   "no_oauth": 0,
   "imgdir": "/build/images",
   "ec2_ami_type": "ebs",
-  "rhevm_image_format": "qcow2",
-  "openstack_image_format": "qcow2",
   "clients": {
     "mock-key": "mock-secret"
     },

--- a/config/ova.json
+++ b/config/ova.json
@@ -1,4 +1,5 @@
 {
+  "generate_icicle": false,
   "ovf_cpu_count": "4",
   "ovf_memory_mb": "6144",
   "rhevm_description": "ManageIQ",

--- a/config/target.json
+++ b/config/target.json
@@ -1,5 +1,3 @@
 {
-  "generate_icicle": false,
-  "openstack_image_format": "qcow2",
-  "rhevm_image_format": "qcow2"
+  "generate_icicle": false
 }

--- a/config/target.json
+++ b/config/target.json
@@ -1,0 +1,5 @@
+{
+  "generate_icicle": false,
+  "openstack_image_format": "qcow2",
+  "rhevm_image_format": "qcow2"
+}

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -95,6 +95,7 @@ ramfsfile="/boot/initramfs-$kversion.img"
 
 <%= render_partial "post/azure" if @target == "azure" %>
 <%= render_partial "post/gce" if @target == "gce" %>
+<%= render_partial "post/vagrant" if @target == "vagrant" %>
 
 # make sure there is a new line at the end of sshd_config
 echo "" >> /etc/ssh/sshd_config

--- a/kickstarts/partials/post/vagrant.ks.erb
+++ b/kickstarts/partials/post/vagrant.ks.erb
@@ -1,0 +1,23 @@
+# Add a user "vagrant" with password "vagrant" and a well known public key.
+# Note this is how Vagrant works. You are assumed not to use a Vagrant box on
+# a publicly acessible network.
+useradd vagrant -p b1HEow3cJo7Nc
+
+cat << EOM > /etc/sudoers.d/vagrant-nopasswd
+Defaults:vagrant !requiretty
+vagrant ALL=(ALL) NOPASSWD:ALL
+EOM
+sed -i 's/.*UseDNS.*/UseDNS no/' /etc/ssh/sshd_config
+chmod 400 /etc/sudoers.d/vagrant-nopasswd
+
+mkdir -m 0700 -p ~vagrant/.ssh
+cat << EOM > ~vagrant/.ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
+EOM
+chmod 600 ~vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant ~vagrant/.ssh/
+
+cat << EOM >> ~vagrant/.bashrc
+umask 022
+alias appliance_console='sudo appliance_console'
+EOM

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -23,17 +23,17 @@ module Build
       @ssui_checkout      = ssui_checkout
     end
 
-    def run(task = :all)
+    def run
+      FileUtils.mkdir_p(@ks_gen_base)
+
       targets.each do |target|
         @target = target # used during ERB evaluation
 
         result = evaluate_erb
 
-        FileUtils.mkdir_p(@ks_gen_base)
-        File.write(@ks_gen_base.join("base.ks"), result)
-
-        write_config(result) if [:all, :config].include?(task)
-        write_json(result)   if [:all, :json].include?(task)
+        file = @ks_gen_base.join("base-#{@target}.ks")
+        $log.info("Writing kickstart file: #{file}") if $log
+        File.write(file, result)
       end
     end
 
@@ -42,23 +42,6 @@ module Build
     end
 
     private
-
-    def write_config(result)
-      file = @ks_gen_base.join("base-#{@target}.cfg")
-      $log.info("Writing kickstart in config format: #{file}") if $log
-      File.write(file, result)
-    end
-
-    def write_json(result)
-      json = {
-        "install_script"  => result,
-        "generate_icicle" => false
-      }.to_json
-
-      file = @ks_gen_base.join("base-#{@target}.json")
-      $log.info("Writing kickstart in json format: #{file}") if $log
-      File.write(file, json)
-    end
 
     def evaluate_erb
       ks_file = Productization.file_for(@build_base, "#{KS_DIR}/base.ks.erb")

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,11 +4,11 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant)
     end
 
     it "all" do
-      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure)
+      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant)
     end
 
     it "only vsphere and ovirt" do

--- a/scripts/spec/kickstart_generator_spec.rb
+++ b/scripts/spec/kickstart_generator_spec.rb
@@ -5,7 +5,7 @@ describe Build::KickstartGenerator do
   describe "#run" do
     let(:build_base) { data_file_path("kickstart_generator") }
     let(:generated)  { "#{build_base}/kickstarts/generated" }
-    let(:ks_text)    { File.read("#{generated}/base.ks") }
+    let(:ks_text)    { File.read("#{generated}/base-target.ks") }
 
     subject { described_class.new(build_base, ["target"], "puddle", "miq_checkout", "app_checkout", "ssui_checkout") }
 
@@ -14,22 +14,22 @@ describe Build::KickstartGenerator do
     end
 
     it "writes ks file" do
-      subject.run(nil)
+      subject.run
       expect(ks_text).to include("base file text")
     end
 
     it "renders partial files" do
-      subject.run(nil)
+      subject.run
       expect(ks_text).to include("first partial file text")
     end
 
     it "renders partials in partial files" do
-      subject.run(nil)
+      subject.run
       expect(ks_text).to include("second partial file text")
     end
 
     it "renders partial files in subdirectories" do
-      subject.run(nil)
+      subject.run
       expect(ks_text).to include("subdir partial text")
     end
   end

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -26,11 +26,11 @@ describe Build::Target do
   end
 
   it ".supported_types" do
-    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure)
+    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant)
   end
 
   it ".default_types" do
-    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure)
+    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant)
   end
 
   it "#to_s" do

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -1,13 +1,13 @@
 module Build
   class Target
-    ImagefactoryMetadata = Struct.new(:imagefactory_type, :file_extension)
+    ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension)
 
     TYPES = {
-      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'ova'),
-      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'ova'),
-      'openstack' => ImagefactoryMetadata.new('openstack-kvm', 'qc2'),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', 'vhd'),
-      'azure'     => ImagefactoryMetadata.new('azure', 'vhd')
+      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova'),
+      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova'),
+      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2'),
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
+      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd')
     }
 
     attr_reader :name
@@ -27,6 +27,10 @@ module Build
 
     def imagefactory_type
       TYPES.fetch(name).imagefactory_type
+    end
+
+    def ova_format
+      TYPES.fetch(name).ova_format
     end
 
     def file_extension

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -7,7 +7,8 @@ module Build
       'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova'),
       'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2'),
       'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
-      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd')
+      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
+      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box')
     }
 
     attr_reader :name


### PR DESCRIPTION
This patch series adds support for building Vagrant "boxes". There's two patches in the series, one prepares support for multiple OVA formats, and the second patch uses that to add in Vagrant support.

Vagrant boxes are (Vagrant) provider specific. This builds a box for the VirtualBox provider, which is the most common one. Other formats can be added later. Also no upload to Atlas is implemented yet.