### PR TITLE
Add kickstart file changes for AWS EC2

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -93,6 +93,7 @@ kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"
 /sbin/dracut --force --add-drivers "mptbase mptscsih mptspi<%= " hv_storvsc hid_hyperv hv_netvsc hv_vmbus" if @target == "hyperv" || @target == "azure" %>" $ramfsfile $kversion
 
+<%= render_partial "post/aws-ec2" if @target == "aws-ec2" %>
 <%= render_partial "post/azure" if @target == "azure" %>
 <%= render_partial "post/gce" if @target == "gce" %>
 <%= render_partial "post/vagrant" if @target == "vagrant" %>

--- a/kickstarts/partials/main/bootloader.ks.erb
+++ b/kickstarts/partials/main/bootloader.ks.erb
@@ -1,4 +1,4 @@
-<% if @target == "openstack" %>
+<% if @target == "aws-ec2" || @target == "openstack" %>
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
 <% elsif @target == "azure" %>
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"

--- a/kickstarts/partials/main/network.ks.erb
+++ b/kickstarts/partials/main/network.ks.erb
@@ -1,4 +1,4 @@
-<% if @target == "openstack" || @target == "azure" %>
+<% if @target == "aws-ec2" || @target == "azure" || @target == "openstack" %>
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 <% elsif @target == "gce" %>
 network --onboot yes --device eth0 --bootproto dhcp --noipv6 --mtu=1460

--- a/kickstarts/partials/post/aws-ec2.ks.erb
+++ b/kickstarts/partials/post/aws-ec2.ks.erb
@@ -1,0 +1,9 @@
+cat >> /etc/cloud/cloud.cfg.d/20_miq_user.cfg << EOF
+disable_root: true
+ssh_pwauth: false
+users:
+  - default
+EOF
+
+# Lock root account
+usermod -L root


### PR DESCRIPTION
Undo cloud-init cfg settings that come from manageiq-appliance repo.
For AWS EC2, need to disable root/password login, and only allow ssh key access.

The default user cloud-init creates on CentOS is "centos".

Requires https://github.com/ManageIQ/manageiq-appliance/pull/87

@Fryguy @carbonin please review