### PR TITLE
Fix when building from tag

### DIFF
--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -46,18 +46,12 @@ FILE_SERVER_BASE    = Pathname.new(ENV["BUILD_FILE_SERVER_BASE"] || ".") # Subdi
 if !cli_options[:local] && cli_options[:build_url]
   build_repo = cli_options[:build_url]
   cfg_base = REFS_DIR.join(cli_options[:build_ref])
+  FileUtils.rm_rf(cfg_base)
   FileUtils.mkdir_p(cfg_base)
   Dir.chdir(cfg_base) do
-    unless File.exist?(".git")
-      $log.info("Cloning Repo #{build_repo} to #{cfg_base} ...")
-      `git clone #{build_repo} .` unless File.exist?(".git")
-    end
-    $log.info("Checking out reference #{cli_options[:build_ref]} from repo #{build_repo} ...")
-    `git reset --hard`                                    # Drop any local changes
-    `git clean -dxf`                                      # Clean up any local untracked changes
-    `git checkout #{cli_options[:build_ref]}`             # Checkout existing branch
-    `git fetch origin`                                    # Get origin updates
-    `git reset --hard origin/#{cli_options[:build_ref]}`  # Reset the branch to the origin
+    $log.info("Cloning Repo #{build_repo} to #{cfg_base} ...")
+    `git clone #{build_repo} .`
+    `git checkout #{cli_options[:build_ref]}`             # Checkout existing tag or branch
   end
 
   unless File.exist?(cfg_base)


### PR DESCRIPTION
Old code (all run as subshells):

  git reset --hard
  git clean -dxf
  git checkout <ref>
  git fetch origin
  git reset --hard origin/<ref>

The last line only works when the --reference <ref> parameter is a
branch. The build does not fail though, because a subshell failing
doesn't exit the Ruby interpreter. So the code was in essence a NOP in
case of a branch.

However, if I understand the old code correctly, there is another issue.
If you build from a new tag for the first time, the code would actually
not build that tag but whatever was there before. This is because the
"git fetch" is done after the "git checkout <ref>". This could actually
have lead to releases that don't correspond to their tag :-D

The new code looks like this:

  rm -rf /build/references/<ref>
  chdir /build/references/<ref>
  git clone <url> .
  git checkout <ref>

The "rm -rf" should be innocuous. It will never remove your working repo
which is at /build/manageiq-appliance-build. It will only remove a repo
that the script itself checked out. It's safe even if you forget --local.