### PR TITLE
[DARGA] Backport Vagrant support from master.

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -96,6 +96,7 @@ ramfsfile="/boot/initramfs-$kversion.img"
 <%= render_partial "post/aws-ec2" if @target == "aws-ec2" %>
 <%= render_partial "post/azure" if @target == "azure" %>
 <%= render_partial "post/gce" if @target == "gce" %>
+<%= render_partial "post/vagrant" if @target == "vagrant" %>
 
 # make sure there is a new line at the end of sshd_config
 echo "" >> /etc/ssh/sshd_config

--- a/kickstarts/partials/post/vagrant.ks.erb
+++ b/kickstarts/partials/post/vagrant.ks.erb
@@ -1,0 +1,23 @@
+# Add a user "vagrant" with password "vagrant" and a well known public key.
+# Note this is how Vagrant works. You are assumed not to use a Vagrant box on
+# a publicly acessible network.
+useradd vagrant -p b1HEow3cJo7Nc
+
+cat << EOM > /etc/sudoers.d/vagrant-nopasswd
+Defaults:vagrant !requiretty
+vagrant ALL=(ALL) NOPASSWD:ALL
+EOM
+sed -i 's/.*UseDNS.*/UseDNS no/' /etc/ssh/sshd_config
+chmod 400 /etc/sudoers.d/vagrant-nopasswd
+
+mkdir -m 0700 -p ~vagrant/.ssh
+cat << EOM > ~vagrant/.ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
+EOM
+chmod 600 ~vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant ~vagrant/.ssh/
+
+cat << EOM >> ~vagrant/.bashrc
+umask 022
+alias appliance_console='sudo appliance_console'
+EOM


### PR DESCRIPTION
Allow building Vagrant images for Darga.

This only brings back the changes to the kickstart files. It is intended
to use the master build repo to build a Darga release.