### PR TITLE
Change postgres disk mountpoint

### DIFF
--- a/kickstarts/partials/main/db_fs.ks.erb
+++ b/kickstarts/partials/main/db_fs.ks.erb
@@ -1,3 +1,3 @@
 part pv.2             --ondrive=vda                     --size=10240 --grow
 volgroup vg_data      --pesize=4096 pv.2
-logvol /var/opt/rh/rh-postgresql95/lib/pgsql/data --name=lv_pg --vgname=vg_data --size=8192 --grow --fstype=xfs
+logvol /var/opt/rh/rh-postgresql95/lib/pgsql --name=lv_pg --vgname=vg_data --size=8192 --grow --fstype=xfs


### PR DESCRIPTION
This will allow us to upgrade postgresql versions more easily by creating the new data directory next to the old one on the same volume.

This will allow us to mount the volume at the new path (e.g. `/var/opt/rh/rh-postgresql95/lib/pgsql`) while also having separate data directories for the upgrade and allowing us to use hardlinks to perform the upgrade to save space on the disk.

@jrafanie please review
/cc @gtanzillo @Fryguy 