### PR TITLE
Add optional post-build compression step

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Below are instructions on installing and configuring a virtual machine to genera
   yum install ruby
   yum install ruby-devel
   yum install zlib-devel
+  yum install zip unzip
 
   gem install trollop
   gem install fog

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -20,6 +20,10 @@ describe Build::Target do
     expect(described_class.new("openstack").file_extension).to eql "qc2"
   end
 
+  it "#compression_type" do
+    expect(described_class.new("openstack").compression_type).to eql nil
+  end
+
   it "#sort" do
     targets = [described_class.new("vsphere"), described_class.new("openstack")]
     expect(targets.sort.collect(&:name)).to eql %w(openstack vsphere)

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -1,16 +1,16 @@
 module Build
   class Target
-    ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension)
+    ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension, :compression_type)
 
     TYPES = {
-      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova'),
-      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova'),
-      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2'),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
-      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
-      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box'),
-      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2'),
-      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz'),
+      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil),
+      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova', nil),
+      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', nil),
+      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd', nil),
+      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil),
+      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
+      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil),
     }
 
     attr_reader :name
@@ -38,6 +38,10 @@ module Build
 
     def file_extension
       TYPES.fetch(name).file_extension
+    end
+
+    def compression_type
+      TYPES.fetch(name).compression_type
     end
 
     def <=>(other)


### PR DESCRIPTION
There are a few current and future appliances where the output of imagefactory is a non-compressed format. This patch adds support for an optional post-build compression step to reduce the size of those images.

The supported formats are "gzip" for cases where the users are mostly Unix/Linux people, and "zip" for Windows folks.

This PR doesn't yet enable any compression. However I would suggest we enable in a future PR:
- ZIP compression for Azure (given the Windows audience). This will bring   down the appliance size of 3.3GB to a size similar to the other appliances  (currently roughtly 1GB for the nightly builds).
- ZIP compression for HyperV. Same situation as Azure.
- GZIP compression for EC2 (once EC2 PR has been enabled). The native image   format for EC2 is a sparse RAW file which will be 50GB in size. This is  not practical and must be compressed.
