### PR TITLE
Add socat RPM to installed packages.

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -48,6 +48,7 @@ rh-repmgr95
 smem                             # for PSS, USS with forked processes
 scl-utils
 scl-utils-build                  # build requires
+socat                            # for proxying remote consoles
 telnet
 yum-utils
 zip                              # build requires


### PR DESCRIPTION
This is needed for the 2nd lever proxying of VNC/SPICE consoles.

needed by https://github.com/ManageIQ/manageiq/pull/11273

ping @simaishi: need this for Euwe :-(