### PR TITLE
Remove npm updating itself

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,4 +1,3 @@
-npm install -g npm
 npm install -g gulp bower
 
 pushd /var/www/miq/vmdb


### PR DESCRIPTION
EPEL now has npm v3.10.3 and there is no need to update npm now.
Having this line causes build failure.