### PR TITLE
Change the name of the repmgr package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -44,7 +44,7 @@ rh-postgresql95-postgresql-devel    # for pg gem
 rh-postgresql95-postgresql-server   # appliance section
 rh-postgresql95-postgresql-pglogical-output
 rh-postgresql95-postgresql-pglogical
-rh-repmgr95
+rh-postgresql95-repmgr
 smem                             # for PSS, USS with forked processes
 scl-utils
 scl-utils-build                  # build requires


### PR DESCRIPTION
This is the proper name for a package built for SCL
Fixes #145

Requires #174 

https://bugzilla.redhat.com/show_bug.cgi?id=1383795