### PR TITLE
[DARGA] Use 'manageiq' copr account to host RPM

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -12,4 +12,4 @@ repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum
 <% end %>
 
 # Please also add to "post install repos" post/repos partial
-repo --name=manageiq-scl --baseurl=http://copr-be.cloud.fedoraproject.org/results/abellott/manageiq-scl/epel-7-x86_64/
+repo --name=manageiq --baseurl=http://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ/epel-7-x86_64/

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -3,7 +3,7 @@
 # Please also add to "build time repos" main/repos partial
 
 pushd /etc/yum.repos.d/
-  wget https://copr.fedorainfracloud.org/coprs/abellott/manageiq-scl/repo/epel-7/abellott-manageiq-scl-epel-7.repo
+  wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ/repo/epel-7/manageiq-ManageIQ-epel-7.repo
   wget https://copr.fedorainfracloud.org/coprs/rhscl/rh-postgresql94/repo/epel-7/rhscl-rh-postgresql94-epel-7.repo
   wget https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
 popd


### PR DESCRIPTION
master PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/174

'wmi' package was forked from 'abellott' account into 'manageiq' account

The new repo also contains freeipmi 1.5.1-2 for:
https://bugzilla.redhat.com/show_bug.cgi?id=1381655 (master)
https://bugzilla.redhat.com/show_bug.cgi?id=1383368 (darga)

(cherry picked from commit c98e44be9447f2885e916073e1f3cb163b42f02e)
