### PR TITLE
Add Chinese and Japanese fonts for PDF reports

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -104,3 +104,9 @@ hyperv-daemons
 google-compute-engine
 google-config
 <% end %>
+
+# Chinese and Japanese fonts for PDF reports
+cjkuni-ukai-fonts
+cjkuni-uming-fonts
+vlgothic-fonts
+vlgothic-p-fonts


### PR DESCRIPTION
These fonts are then used by prince to create PDF reports
in Chinese and Japanese locales.

https://bugzilla.redhat.com/show_bug.cgi?id=1386217