### PR TITLE
Install unzip package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -50,6 +50,7 @@ scl-utils
 scl-utils-build                  # build requires
 socat                            # for proxying remote consoles
 telnet
+unzip
 yum-utils
 zip                              # build requires
 


### PR DESCRIPTION
Install the unzip package to allow for unzipping files and aid in installing agents on the appliance.