### PR TITLE
Rename ssui repo

### DIFF
--- a/bin/kickstart_build.rb
+++ b/bin/kickstart_build.rb
@@ -19,4 +19,4 @@ Build::KickstartGenerator.new(
   nil,
   Build::GitCheckout.new(:remote => options[:manageiq_url],  :ref => options[:manageiq_ref]),
   Build::GitCheckout.new(:remote => options[:appliance_url], :ref => options[:appliance_ref]),
-  Build::GitCheckout.new(:remote => options[:ssui_url],      :ref => options[:ssui_ref])).run
+  Build::GitCheckout.new(:remote => options[:sui_url],       :ref => options[:sui_ref])).run

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -86,7 +86,7 @@ cloud-init
 
 wmi
 
-# bower; Self Service UI (in devel mode)
+# bower; Service UI (in devel mode)
 npm
 
 <% if @target == "ovirt" %>

--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -12,7 +12,7 @@ pushd /var/www/miq/vmdb
   bundle install
 popd
 
-pushd /opt/manageiq/manageiq-ui-self_service
+pushd /opt/manageiq/manageiq-ui-service
   # overriding exported BUNDLE_GEMFILE
   bundle install --gemfile Gemfile
 popd

--- a/kickstarts/partials/post/source_setup.ks.erb
+++ b/kickstarts/partials/post/source_setup.ks.erb
@@ -5,7 +5,7 @@ vmdb_root="$app_root/vmdb"
 repos_root="/opt/manageiq"
 manageiq_root="$repos_root/manageiq"
 appliance_root="$repos_root/manageiq-appliance"
-ssui_root="$repos_root/manageiq-ui-self_service"
+ssui_root="$repos_root/manageiq-ui-service"
 
 <%= git_checkout(@appliance_checkout, "$appliance_root") %>
 

--- a/kickstarts/partials/post/source_setup.ks.erb
+++ b/kickstarts/partials/post/source_setup.ks.erb
@@ -5,13 +5,13 @@ vmdb_root="$app_root/vmdb"
 repos_root="/opt/manageiq"
 manageiq_root="$repos_root/manageiq"
 appliance_root="$repos_root/manageiq-appliance"
-ssui_root="$repos_root/manageiq-ui-service"
+sui_root="$repos_root/manageiq-ui-service"
 
 <%= git_checkout(@appliance_checkout, "$appliance_root") %>
 
 <%= git_checkout(@manageiq_checkout, "$vmdb_root") %>
 
-# Symlink manageiq to the vmdb root so that the SSUI can build into it
+# Symlink manageiq to the vmdb root so that the service UI can build into it
 ln -vs $vmdb_root $manageiq_root
 
 # Replace the log directory with the larger logvol
@@ -19,7 +19,7 @@ mkdir -p /var/log/manageiq
 rm -rf $vmdb_root/log
 ln -vs /var/log/manageiq $vmdb_root/log
 
-<%= git_checkout(@ssui_checkout, "$ssui_root") %>
+<%= git_checkout(@sui_checkout, "$sui_root") %>
 
 $appliance_root/setup
 mkdir -p $app_root/vmdb/log/apache

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -7,8 +7,8 @@ pushd /var/www/miq/vmdb
   rake evm:compile_sti_loader
 popd
 
-# Self Service UI
-pushd /opt/manageiq/manageiq-ui-self_service
+# Service UI
+pushd /opt/manageiq/manageiq-ui-service
   npm install
   bower -F --allow-root install
   gulp build

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -11,7 +11,7 @@ module Build
     MANAGEIQ_URL  = "https://github.com/ManageIQ/manageiq.git"
     APPLIANCE_URL = "https://github.com/ManageIQ/manageiq-appliance.git"
     BUILD_URL     = "https://github.com/ManageIQ/manageiq-appliance-build.git"
-    SSUI_URL      = "https://github.com/ManageIQ/manageiq-ui-service.git"
+    SUI_URL       = "https://github.com/ManageIQ/manageiq-ui-service.git"
 
     def parse(args = ARGV)
       git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"
@@ -22,7 +22,7 @@ module Build
       manageiq_desc  = "Repo URL containing the ManageIQ code"
       appliance_desc = "Repo URL containing appliance scripts and configs(COPY/LINK/TEMPLATE)"
       build_desc     = "Repo URL containing the build config and kickstart"
-      ssui_desc      = "Repo URL containing the ManageIQ self service UI code"
+      sui_desc       = "Repo URL containing the ManageIQ service UI code"
       upload_desc    = "Upload appliance builds to the website"
       only_desc      = "Build only specific image types.  Example: --only ovirt openstack.  Defaults to all images."
 
@@ -39,8 +39,8 @@ module Build
         opt :manageiq_ref,  git_ref_desc,   :type => :string,  :short => "m", :default => DEFAULT_REF
         opt :manageiq_url,  manageiq_desc,  :type => :string,  :short => "M", :default => MANAGEIQ_URL
         opt :only,          only_desc,      :type => :strings, :short => "o", :default => Target.default_types
-        opt :ssui_ref,      git_ref_desc,   :type => :string,  :short => "s", :default => DEFAULT_REF
-        opt :ssui_url,      ssui_desc,      :type => :string,  :short => "S", :default => SSUI_URL
+        opt :sui_ref,       git_ref_desc,   :type => :string,  :short => "s", :default => DEFAULT_REF
+        opt :sui_url,       sui_desc,       :type => :string,  :short => "S", :default => SUI_URL
         opt :type,          type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
         opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
       end
@@ -52,7 +52,7 @@ module Build
       end
 
       # --reference overrides all other reference arguments
-      [:manageiq_ref, :appliance_ref, :build_ref, :ssui_ref].each do |ref|
+      [:manageiq_ref, :appliance_ref, :build_ref, :sui_ref].each do |ref|
         options[ref] = (options[:reference] || options[ref]).to_s.strip
       end
       Trollop.die(:manageiq_ref, git_ref_desc) if options[:manageiq_ref].to_s.empty?

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -11,7 +11,7 @@ module Build
     MANAGEIQ_URL  = "https://github.com/ManageIQ/manageiq.git"
     APPLIANCE_URL = "https://github.com/ManageIQ/manageiq-appliance.git"
     BUILD_URL     = "https://github.com/ManageIQ/manageiq-appliance-build.git"
-    SSUI_URL      = "https://github.com/ManageIQ/manageiq-ui-self_service.git"
+    SSUI_URL      = "https://github.com/ManageIQ/manageiq-ui-service.git"
 
     def parse(args = ARGV)
       git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -12,16 +12,16 @@ module Build
     KS_GEN_DIR  = "#{KS_DIR}/generated"
     KS_PART_DIR = "#{KS_DIR}/partials"
 
-    attr_reader :targets, :puddle, :manageiq_checkout, :appliance_checkout, :ssui_checkout
+    attr_reader :targets, :puddle, :manageiq_checkout, :appliance_checkout, :sui_checkout
 
-    def initialize(build_base, targets, puddle, manageiq_checkout, appliance_checkout, ssui_checkout)
+    def initialize(build_base, targets, puddle, manageiq_checkout, appliance_checkout, sui_checkout)
       @build_base         = Pathname.new(build_base)
       @ks_gen_base        = @build_base.join(KS_GEN_DIR)
       @targets            = targets
       @puddle             = puddle # used during ERB evaluation
       @manageiq_checkout  = manageiq_checkout
       @appliance_checkout = appliance_checkout
-      @ssui_checkout      = ssui_checkout
+      @sui_checkout       = sui_checkout
     end
 
     def run

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -23,42 +23,42 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(--reference branch_name)).options[:appliance_ref]).to eq("branch_name")
       expect(described_class.new.parse(%w(--reference branch_name)).options[:build_ref]).to     eq("branch_name")
       expect(described_class.new.parse(%w(--reference branch_name)).options[:manageiq_ref]).to  eq("branch_name")
-      expect(described_class.new.parse(%w(--reference branch_name)).options[:ssui_ref]).to      eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:sui_ref]).to       eq("branch_name")
     end
 
     it "with a branch name for appliance reference" do
       expect(described_class.new.parse(%w(-a branch_name)).options[:appliance_ref]).to eq("branch_name")
       expect(described_class.new.parse(%w(-a branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(-a branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-a branch_name)).options[:ssui_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:sui_ref]).to       eq("master")
     end
 
     it "with a branch name for build reference" do
       expect(described_class.new.parse(%w(-b branch_name)).options[:appliance_ref]).to eq("master")
       expect(described_class.new.parse(%w(-b branch_name)).options[:build_ref]).to     eq("branch_name")
       expect(described_class.new.parse(%w(-b branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-b branch_name)).options[:ssui_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:sui_ref]).to       eq("master")
     end
 
     it "with a branch name for manageiq reference" do
       expect(described_class.new.parse(%w(-m branch_name)).options[:appliance_ref]).to eq("master")
       expect(described_class.new.parse(%w(-m branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(-m branch_name)).options[:manageiq_ref]).to  eq("branch_name")
-      expect(described_class.new.parse(%w(-m branch_name)).options[:ssui_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:sui_ref]).to       eq("master")
     end
 
-    it "with a branch name for ssui reference" do
+    it "with a branch name for sui reference" do
       expect(described_class.new.parse(%w(-s branch_name)).options[:appliance_ref]).to eq("master")
       expect(described_class.new.parse(%w(-s branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(-s branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-s branch_name)).options[:ssui_ref]).to      eq("branch_name")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:sui_ref]).to       eq("branch_name")
     end
 
     it "with DEFAULT_REF for reference override" do
       expect(described_class.new.parse(%w(--reference master -a branch_name)).options[:appliance_ref]).to eq("master")
       expect(described_class.new.parse(%w(--reference master -b branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(--reference master -m branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(--reference master -s branch_name)).options[:ssui_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(--reference master -s branch_name)).options[:sui_ref]).to       eq("master")
     end
 
     it "release without reference" do

--- a/scripts/spec/kickstart_generator_spec.rb
+++ b/scripts/spec/kickstart_generator_spec.rb
@@ -7,7 +7,7 @@ describe Build::KickstartGenerator do
     let(:generated)  { "#{build_base}/kickstarts/generated" }
     let(:ks_text)    { File.read("#{generated}/base-target.ks") }
 
-    subject { described_class.new(build_base, ["target"], "puddle", "miq_checkout", "app_checkout", "ssui_checkout") }
+    subject { described_class.new(build_base, ["target"], "puddle", "miq_checkout", "app_checkout", "sui_checkout") }
 
     after do
       FileUtils.rm_rf(generated)

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -88,8 +88,8 @@ targets = cli_options[:only].collect { |only| Build::Target.new(only) }
 
 manageiq_checkout  = Build::GitCheckout.new(:remote => cli_options[:manageiq_url],  :ref => cli_options[:manageiq_ref])
 appliance_checkout = Build::GitCheckout.new(:remote => cli_options[:appliance_url], :ref => cli_options[:appliance_ref])
-ssui_checkout      = Build::GitCheckout.new(:remote => cli_options[:ssui_url],      :ref => cli_options[:ssui_ref])
-ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:only], puddle, manageiq_checkout, appliance_checkout, ssui_checkout)
+sui_checkout       = Build::GitCheckout.new(:remote => cli_options[:sui_url],       :ref => cli_options[:sui_ref])
+ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:only], puddle, manageiq_checkout, appliance_checkout, sui_checkout)
 ks_gen.run
 
 file_rdu_dir_base = FILE_SERVER_BASE.join(directory)


### PR DESCRIPTION
Split to 2 commits:

eebebde - to rename the actual directory/repo used

964c58b - everywhere else used internally in variables, etc. to make it consistent (doesn't affect the resulting appliance)

There will be another PR that will follow this, to update the SUI build steps needed on 'master' (unrelated to the rename).
