### PR TITLE
Change target from 'aws-ec2' to 'ec2' in partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Below are instructions on installing and configuring a virtual machine to genera
 ## Setup Imagefactory:
 
   * Clone imagefactory as /build/imagefactory (requires git tag 0adeb22
-    or later for google compute engine support):
+    or later for EC2 support):
 
     ```
     cd /build

--- a/kickstarts/partials/main/bootloader.ks.erb
+++ b/kickstarts/partials/main/bootloader.ks.erb
@@ -1,4 +1,4 @@
-<% if @target == "aws-ec2" || @target == "openstack" %>
+<% if @target == "ec2" || @target == "openstack" %>
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
 <% elsif @target == "azure" %>
 bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"

--- a/kickstarts/partials/main/network.ks.erb
+++ b/kickstarts/partials/main/network.ks.erb
@@ -1,4 +1,4 @@
-<% if @target == "aws-ec2" || @target == "azure" || @target == "openstack" %>
+<% if @target == "ec2" || @target == "azure" || @target == "openstack" %>
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 <% elsif @target == "gce" %>
 network --onboot yes --device eth0 --bootproto dhcp --noipv6 --mtu=1460


### PR DESCRIPTION
When target name was changed from 'aws-ec2' to 'ec2' in https://github.com/ManageIQ/manageiq-appliance-build/pull/161, 2 files got missed.

Also fixed README.