### PR TITLE
Use a single versioned repo to pull rpms built by us

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -6,10 +6,9 @@ repo --name=epel    --baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
 
 # repos to install packages not found in the os
 repo --name=centos-scl --baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
-repo --name=pglogical-scl --baseurl=https://copr-be.cloud.fedoraproject.org/results/ncarboni/pglogical-SCL/epel-7-x86_64/
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-compute-el7-x86_64/
 <% end %>
 
 # Please also add to "post install repos" post/repos partial
-repo --name=manageiq --baseurl=http://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ/epel-7-x86_64/
+repo --name=manageiq-ManageIQ-Fine --baseurl=https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Fine/epel-7-x86_64/

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -42,7 +42,6 @@ openslp-devel                    # build requires
 rh-postgresql95-postgresql          # appliance section
 rh-postgresql95-postgresql-devel    # for pg gem
 rh-postgresql95-postgresql-server   # appliance section
-rh-postgresql95-postgresql-pglogical-output
 rh-postgresql95-postgresql-pglogical
 rh-postgresql95-repmgr
 smem                             # for PSS, USS with forked processes

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -3,8 +3,7 @@
 # Please also add to "build time repos" main/repos partial
 
 pushd /etc/yum.repos.d/
-  wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ/repo/epel-7/manageiq-ManageIQ-epel-7.repo
-  wget https://copr.fedorainfracloud.org/coprs/ncarboni/pglogical-SCL/repo/epel-7/ncarboni-pglogical-SCL-epel-7.repo
+  wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Fine/repo/epel-7/manageiq-ManageIQ-Fine-epel-7.repo
 popd
 
 <% if @target == "gce" %>


### PR DESCRIPTION
This will allow us to provide different packages for different versions of ManageIQ

Also, there is a new version (1.2.1) of the pglogical package provided in this repo.

https://www.pivotaltracker.com/story/show/125274621

@simaishi @gtanzillo please review