### PR TITLE
Install ruby-install from rpm rather than from source

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -12,3 +12,4 @@ repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum
 
 # Please also add to "post install repos" post/repos partial
 repo --name=manageiq-ManageIQ-Fine --baseurl=https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Fine/epel-7-x86_64/
+repo --name=postmodern-ruby-install --baseurl=https://copr-be.cloud.fedoraproject.org/results/postmodern/ruby-install/fedora-25-$basearch/

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -10,6 +10,7 @@ ipmitool
 # ruby dependencies auto-installed by ruby-install
 # prefer to have these dependencies explicitly required in the kickstart
 # https://github.com/postmodern/ruby-install/blob/8957e0d1a52d59b45cf48cef8f15a1d8ed921cd4/share/ruby-install/ruby/dependencies.txt
+ruby-install
 automake
 gcc
 gdbm-devel

--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -1,9 +1,3 @@
-curl -L https://github.com/postmodern/ruby-install/archive/v0.6.0.tar.gz | tar xvfzC - /tmp
-
-pushd /tmp/ruby-install*/
-make install
-popd
-
 # The ruby-install will result in about 350MiB of files in /usr/local/src.
 # These do not need to be in the image, so put them on a tmpfs.
 mkdir -p /usr/local/src

--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -7,7 +7,7 @@ mount -t tmpfs tmpfs /usr/local/src
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-/usr/local/bin/ruby-install ruby 2.3.1 -- --disable-install-doc --enable-shared
+ruby-install ruby 2.3.1 -- --disable-install-doc --enable-shared
 
 # Free up tmpfs memory.
 umount /usr/local/src


### PR DESCRIPTION
Use the ruby-install rpm here https://copr-be.cloud.fedoraproject.org/results/postmodern/ruby-install/fedora-25-x86_64/00492646-ruby-install/

This way we don't have to build ruby-install from source every time we build an appliance.