### PR TITLE
Add the wget package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -49,6 +49,7 @@ scl-utils
 scl-utils-build                  # build requires
 socat                            # for proxying remote consoles
 telnet
+wget                             # build requires
 yum-utils
 zip                              # build requires
 


### PR DESCRIPTION
It is required for the build and was not previously required explicitly.

It must have been being included as a dependency at some point, but is longer present on appliances which is preventing us from downloading the copr repo files we need.

The `manageiq-ManageIQ-Fine-epel-7.repo` file is missing and I am seeing the following in `anaconda-post.log`
```
'/var/www/miq/lib' -> '/var/www/miq/vmdb/gems/pending'
+ [16:44:15] pushd /etc/yum.repos.d/
/etc/yum.repos.d /
+ [16:44:15] wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Fine/repo/epel-7/manageiq-ManageIQ-Fine-epel-7.repo
/tmp/ks-script-NH0n_X: line 104: wget: command not found
+ [16:44:15] popd
```
This also seems to affect euwe.