### PR TITLE
Update Service UI build command

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,4 +1,4 @@
-npm install -g gulp bower yarn
+npm install -g bower yarn
 
 pushd /var/www/miq/vmdb
   bower -F --allow-root install
@@ -10,5 +10,5 @@ popd
 # Service UI
 pushd /opt/manageiq/manageiq-ui-service
   yarn install
-  gulp build
+  yarn run build
 popd


### PR DESCRIPTION
Remove explicit gulp install and replace `gulp build` with new webpack
version of build process. `yarn run build` will kick off the `build`
task designated in `package.json` which will compile the build using the
configuration from `config/webpack.prod.js` in the manageiq-ui-service
directory.

@miq-bot add_label euwe/no

Dependent on ManageIQ/manageiq-ui-service#420