### PR TITLE
Disable mounting ephemeral disk in cloud-init for EC2

### DIFF
--- a/kickstarts/partials/post/ec2.ks.erb
+++ b/kickstarts/partials/post/ec2.ks.erb
@@ -5,5 +5,10 @@ users:
   - default
 EOF
 
+cat >> /etc/cloud/cloud.cfg.d/20_miq_ephemeral_mount.cfg << EOF
+mounts:
+ - [ ephemeral0 ]
+EOF
+
 # Lock root account
 usermod -L root


### PR DESCRIPTION
When .vhd file is imported to EC2 and AMI is created (using `aws ec2 import-image`), a part of the process boots the image which runs cloud-init.  cloud-init finds an ephemeral disk (which I think the AMI creation process adds - there is no log for the import and I can't tell exactly what happens) and add a line to /etc/fstab:

`/dev/xvdb	/mnt	auto	defaults,nofail,comment=cloudconfig	0	2`

This is due to default cloud-init behavior of mounting an ephemeral disk as /mnt.  The import process finishes, the ephemeral disk is disconnected and now AMI is created with just 1 disk.

Then, a user creates an instance from this AMI with an (non ephemeral) external disk.  Since fstab already contains the line for mounting /dev/xvdb as /mnt, it tries to mount the external disk as /mnt, which will break the appliance on next boot if the disk was configured for database, log, etc.

I'll be looking into what's happening during import process.  For now, this change will disable mounting ephemeral disk in cloud-init, so AMI will not have fstab with `/mnt`.  If anyone wants to actually add ephemeral disk for whatever reason, the mount has to be configured manually.  This was approved by PM.

https://bugzilla.redhat.com/show_bug.cgi?id=1413835
