### PR TITLE
Remove the symlink that used to point to gems/pending

### DIFF
--- a/kickstarts/partials/post/source_setup.ks.erb
+++ b/kickstarts/partials/post/source_setup.ks.erb
@@ -28,4 +28,3 @@ cp /etc/motd.manageiq /etc/motd
 
 # Legacy directory symlinks
 ln -vs $appliance_root $app_root/system
-ln -vs $app_root/vmdb/gems/pending $app_root/lib


### PR DESCRIPTION
The directory rooted at $app_root/vmdb/gems/pending has been moved
into a separate gem and is no longer present at that path.

We will not be updating the link location every time the gem
changes versions or we track a new git sha so I'm removing this.