### PR TITLE
Fix gce image upload which has .tar.gz as extension

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -66,8 +66,8 @@ module Build
     end
 
     def release_filename(appliance_name)
-      ext = File.extname(appliance_name)
       name = appliance_name.split("-")
+      ext = name[-1].sub(/\h*/, '')
       name[0..-3].join("-") << ext
     end
   end


### PR DESCRIPTION
The uploader script was uploading the 'release' images with `.gz` extension for GCE images, rather than `.tar.gz` which is required by GCE.

`name[-1]` is `<sha>.<ext>` (e.g. `e286988bff.tar.gz`, `e286988bff.ova`)
