### PR TITLE
Correct line to remove logs from the appliance

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -121,7 +121,7 @@ drivers="$drivers xen-blkfront xen-netfront"
 echo "" >> /etc/ssh/sshd_config
 
 # Clean the logs
-rm -rf "$vmdb_root/log/*"
+rm -vf "$vmdb_root"/log/*.log
 
 chvt 1
 ) 2>&1 | tee /dev/tty3


### PR DESCRIPTION
Previously the quotes were preventing this from working properly.

We should only quote the variable.