### PR TITLE
Explicitly add cronie and logrotate packages

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -24,9 +24,11 @@ zlib-devel
 chrony
 cifs-utils
 cmake                            # For rugged gem
+cronie
 libcurl-devel                    # For curb gem
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem
+logrotate
 lshw                             # From epel
 lvm2
 memcached


### PR DESCRIPTION
They're required for logrotate feature to work, and adding explicitly makes it easier to see what packages are required when working on non-VM appliance (https://github.com/ManageIQ/manageiq-pods/pull/109)