### PR TITLE
Update google compute engine package installation to allow SSH login

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -105,9 +105,6 @@ open-vm-tools
 WALinuxAgent
 <% elsif @target == "hyperv" %>
 hyperv-daemons
-<% elsif @target == "gce" %>
-google-compute-engine
-google-config
 <% end %>
 
 # Chinese and Japanese fonts for PDF reports

--- a/kickstarts/partials/post/gce.ks.erb
+++ b/kickstarts/partials/post/gce.ks.erb
@@ -1,3 +1,18 @@
+# Install google compute engine packages
+# Disable functions that need network/retrieve metadata, as that will not be available in imagefactory installation
+cat >> /etc/default/instance_configs.cfg.template << EOF
+[InstanceSetup]
+network_enabled=false
+
+[NetworkInterfaces]
+setup=false
+EOF
+
+yum install -y google-compute-engine google-compute-engine-init google-config
+
+# Delete cfg files used here, so default cfg file will be created on next boot
+rm -f /etc/default/instance_configs.cfg*
+
 # sshd configuration
 sed -i 's/^#\(ClientAliveInterval\).*$/\1 420/g' /etc/ssh/sshd_config
 sed -i 's/^#\(PermitRootLogin\).*$/\1 no/g' /etc/ssh/sshd_config


### PR DESCRIPTION
Google compute engine packages have changed and that's causing SSH login not to work any more.  

There are 2 issues:

1. One of the packages, `google-compute-engine-init`, enables/starts services using systemctl in RPM post script.  However the rpm doesn't require `systemd` and `google-compute-engine-init` gets installed before `systemd`, causing %post to fail. Because of this, the service that creates a user account to allow SSH access doesn't get enabled/started.

1. After installing the RPMs, initial setup runs.  Some of the steps try to retrieve metadata info or configure network, which doesn't work in ImageFactory/oz environment. Need to disable those steps.

The changes made are:
- moved package installation to kickstart %post section
- created `instance_configs.cfg.template` to override default settings to skip metadata/network related setup
- deleted cfg files used, so default cfg will be generated on next boot

Fixes https://github.com/ManageIQ/manageiq-appliance-build/issues/197