### PR TITLE
bower - die when bower install fails

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,7 +1,8 @@
 npm install -g bower yarn
 
 pushd /var/www/miq/vmdb
-  rake update:bower
+  rake update:bower || exit 1
+
   RAILS_ENV=production rake evm:compile_assets
   rake evm:compile_sti_loader
 popd


### PR DESCRIPTION
Since the UI needs bower dependencies, it makes little sense to continue the build when bower has failed.

Similar to what we do on Travis - https://github.com/ManageIQ/manageiq-ui-classic/blob/master/tools/ci/setup_js_env.sh#L13-L18 .

@abellotti , @simaishi WDYT?

---

Before merging this, please note that I only think this should work, have not tested that `exit 1` in there stops the build. (I am sure that `rake update:bower` returns an exit code on most errors.)