### PR TITLE
Generate the v2_key when we create the database

### DIFF
--- a/kickstarts/partials/post/db_init.ks.erb
+++ b/kickstarts/partials/post/db_init.ks.erb
@@ -4,7 +4,7 @@ cat > /bin/appliance-initialize.sh <<EOF
 [[ -d /var/opt/rh/rh-postgresql95/lib/pgsql/data/base ]] && exit 0
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 echo "Initializing Appliance, please wait ..." > /dev/tty1
-appliance_console_cli --region 0 --internal --password smartvm
+appliance_console_cli --region 0 --internal --password smartvm --key
 EOF
 chmod 755 /bin/appliance-initialize.sh
 


### PR DESCRIPTION
This is more similar to what the container build does and allows us to remove the v2_key generation from initialize_appliance.sh