### PR TITLE
Install http-parser package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -25,6 +25,7 @@ chrony
 cifs-utils
 cmake                            # For rugged gem
 cronie
+http-parser                      # libhttp_parser.so.2 needed by nodejs
 libcurl-devel                    # For curb gem
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem


### PR DESCRIPTION
Newer version of nodejs (v6.10.3) has added dependency for `libhttp_parser` library.  Without explicitly adding http-parser, the build picks up outdated `nodejs010-http-parser` package which causes issue.

cc @chriskacerguis