### PR TITLE
Link the appliance gem dependencies into bundler.d before bundle install

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -8,6 +8,8 @@ export LC_ALL=en_US.UTF-8
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 gem install bundler -v ">=1.8.4"
 
+ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
+
 pushd /var/www/miq/vmdb
   bundle install
 popd


### PR DESCRIPTION
This will add the appliance gems like appliance_console into the same bundle used by the application

Requires https://github.com/ManageIQ/manageiq-appliance/pull/125

/cc @chessbyte @bdunne 