### PR TITLE
Use root login shell to run appliance_console in vagrant

### DIFF
--- a/kickstarts/partials/post/vagrant.ks.erb
+++ b/kickstarts/partials/post/vagrant.ks.erb
@@ -19,5 +19,6 @@ chown -R vagrant:vagrant ~vagrant/.ssh/
 
 cat << EOM >> ~vagrant/.bashrc
 umask 022
-alias appliance_console='sudo appliance_console'
+alias appliance_console='sudo -i appliance_console'
+alias ap=appliance_console
 EOM


### PR DESCRIPTION
Fixes an issue raised in [ManageIQ Talk](http://talk.manageiq.org/t/ruby-missing-in-vagrant-miq/2516).

While looking at it, noticed `ap` has similar problem, so fixed that as well.