### PR TITLE
Allow the DHCPv6 client through the appliance firewall

### DIFF
--- a/kickstarts/partials/post/firewalld.ks.erb
+++ b/kickstarts/partials/post/firewalld.ks.erb
@@ -9,9 +9,10 @@ firewall-offline-cmd --new-zone=manageiq
 firewall-offline-cmd --set-default-zone=manageiq
 
 ###
-# Allow HTTP, HTTPS, SSH and postgresql in the manageiq firewall zone
+# Allow required services in the manageiq firewall zone
 ###
 firewall-offline-cmd --zone=manageiq --add-service=http
 firewall-offline-cmd --zone=manageiq --add-service=https
 firewall-offline-cmd --zone=manageiq --add-service=ssh
 firewall-offline-cmd --zone=manageiq --add-service=postgresql
+firewall-offline-cmd --zone=manageiq --add-service=dhcpv6-client


### PR DESCRIPTION
Before this change appliances would not correctly receive IPv6 addresses via DHCP.

https://bugzilla.redhat.com/show_bug.cgi?id=1473366

/cc @simaishi 