### PR TITLE
Delete temporary files created during build

### DIFF
--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -177,7 +177,7 @@ Dir.chdir(IMGFAC_DIR) do
     end
 
     # The final image is moved out of STORAGE_DIR at this point, delete all other files created during build
-    temp_file_uuid.each { |uuid| FileUtils.rm(Dir.glob("#{STORAGE_DIR}/#{uuid}.*"), :verbose => true) }
+    temp_file_uuid.each { |file_uuid| FileUtils.rm_f(Dir.glob("#{STORAGE_DIR}/#{file_uuid}.*"), :verbose => true) }
   end
 
   passphrase_file = GPG_DIR.join("pass")


### PR DESCRIPTION
Each nightly/release build uses about 180GB in STORAGE_DIR.  Multiple files are created during a build for each target, but only the final image is what we'd need to keep.

We clean up STORAGE_DIR daily using [clean_imagefactory_storage.sh](https://github.com/ManageIQ/manageiq-appliance-build/blob/master/bin/clean_imagefactory_storage.sh) so they're deleted anyway the next day. This change will clean up those files after each build rather than waiting for a day.

I know storage isn't that expensive now... but I have personally never used any of those temporary files within 24 hours after the build, and I didn't see a need to keep them around for a day.