### PR TITLE
Add a script to resize/convert Azure image

### DIFF
--- a/scripts/fix_azure_disk.rb
+++ b/scripts/fix_azure_disk.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require 'awesome_spawn'
+require 'fileutils'
+require 'logger'
+
+log = Logger.new(STDOUT)
+
+def execute(cmd)
+  exit $?.exitstatus unless system(cmd)
+end
+
+disk      = ARGV[0]
+tmp_disk  = disk + ".tmp"
+
+image_type = AwesomeSpawn.run!("qemu-img info --output json #{disk}").output.match(/format\": "(.*)"/)[1]
+if image_type == "vpc"
+  log.info("Converting #{disk} to raw")
+  execute("qemu-img convert -f vpc -O raw #{disk} #{tmp_disk}")
+  FileUtils.mv(tmp_disk, disk)
+end
+
+virtual_size = AwesomeSpawn.run!("qemu-img info --output json #{disk}").output.match(/virtual-size\": ([\d]+)/)[1].to_i
+mega = 1024 * 1024
+new_size = ((virtual_size / mega) + 1) * mega
+log.info("Resizing #{disk} from #{virtual_size} to #{new_size}")
+execute("qemu-img resize -f raw #{disk} #{new_size}")
+
+# We can't use imagefactory target_image due to "fixed" and "force_size" options needed for conversion
+log.info("Converting to fixed vpc")
+execute("qemu-img convert -f raw -O vpc -o subformat=fixed,force_size #{disk} #{tmp_disk}")
+
+FileUtils.mv(tmp_disk, disk)
+log.info("Completed resizing and converting Azure image")


### PR DESCRIPTION
Azure now requires .vhd image to be in fixed format and aligned to nearest 1MB (See "General Linux Installation Notes" in https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic).  This script does the resize/conversion.

Additional change will be required for upstream and downstream separately to actually call this script, along with other needed changes. raw image will be passed for upstream and vpc image will be passed for downstream.

For upstream, I'm having a problem finding`qemu-img` that works end-to-end.
- `>= 2.6.0` is needed for vpc conversion to work properly
- `= 2.6.0` gives an issue with imagefacory in our nested build environment (https://bugzilla.redhat.com/show_bug.cgi?id=1456407)

and 2.6.0 is the latest I can find for CentOS...

https://bugzilla.redhat.com/show_bug.cgi?id=1472972