### PR TITLE
Remove the redis package

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -48,7 +48,6 @@ rh-postgresql95-postgresql-devel    # for pg gem
 rh-postgresql95-postgresql-server   # appliance section
 rh-postgresql95-postgresql-pglogical
 rh-postgresql95-repmgr
-rh-redis32
 smem                             # for PSS, USS with forked processes
 scl-utils
 scl-utils-build                  # build requires

--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -10,7 +10,6 @@ systemctl enable cloud-ds-check
 <% end %>
 
 systemctl enable memcached
-systemctl enable rh-redis32-redis
 
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target


### PR DESCRIPTION
We're not in a situation where we can support either a clustered
redis instance or a single instance which all of our appliances
would point at. These cases would require more management and
configuration than we are prepared to tackle.

The distributed case also will not work because the websocket push
notification would be inserted on the redis instance local to the
server which generated it. This would not necessarily be the same
redis instance which the websocket worker would be watching.

cc @bdunne @skateman 