### PR TITLE
Add qpid-proton-c libs

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -119,3 +119,8 @@ vlgothic-p-fonts
 # For cockpit integration
 cockpit-ws
 cockpit-ssh
+
+# Qpid Proton libs for Nuage provider
+cyrus-sasl
+cyrus-sasl-plain
+qpid-proton-c-devel


### PR DESCRIPTION
qpid-proton-c is required by the Nuage provider to support AMQP eventing (ActiveMQ). The cyrus-sasl packages are required to support the authentication mode Nuage network provider uses in their validated deployments.