### PR TITLE
Add libguestfs tools for OpenStack OpenSCAP

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -124,3 +124,6 @@ cockpit-ssh
 cyrus-sasl
 cyrus-sasl-plain
 qpid-proton-c-devel
+
+# For OpenStack snapshots mount for OpenSCAP scan
+libguestfs-tools


### PR DESCRIPTION
Adding libguestfs-tools package to be able mount OpenStack snapshots
in way suitable to perform OpenSCAP scan.