### PR TITLE
Increase filesystem sizes

### DIFF
--- a/config/base.tdl
+++ b/config/base.tdl
@@ -11,6 +11,6 @@
   </os>
   <description>CentOS73 TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
-    <size>56G</size>
+    <size>66G</size>
   </disk>
 </template>

--- a/config/base.tdl
+++ b/config/base.tdl
@@ -11,6 +11,6 @@
   </os>
   <description>CentOS73 TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
-    <size>50G</size>
+    <size>56G</size>
   </disk>
 </template>

--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -11,6 +11,6 @@
   </os>
   <description>CentOS72 TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
-    <size>51G</size>
+    <size>61G</size>
   </disk>
 </template>

--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -11,6 +11,6 @@
   </os>
   <description>CentOS72 TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
-    <size>45G</size>
+    <size>51G</size>
   </disk>
 </template>

--- a/kickstarts/partials/main/disk_layout.ks.erb
+++ b/kickstarts/partials/main/disk_layout.ks.erb
@@ -2,12 +2,12 @@
 zerombr
 clearpart       --all --drives=vda
 
-part pv.1             --ondrive=vda                   --size=<%= @target == "azure" ? "21504" : "26624" %>
+part pv.1             --ondrive=vda                   --size=<%= @target == "azure" ? "27648" : "32768" %>
 part /boot            --ondrive=vda                   --size=1024  --fstype=xfs
 part /var/www/miq_tmp --ondrive=vda                   --size=10240 --fstype=xfs --fsoptions="rw,noatime,nobarrier"
 
 volgroup vg_system           --pesize=4096 pv.1
-logvol /                     --name=lv_os             --vgname=vg_system --size=4608  --fstype=xfs<%= " --grow" if @target == "azure" %>
+logvol /                     --name=lv_os             --vgname=vg_system --size=10752 --fstype=xfs<%= " --grow" if @target == "azure" %>
 logvol /var                  --name=lv_var            --vgname=vg_system --size=2048  --fstype=xfs
 logvol /var/log              --name=lv_var_log        --vgname=vg_system --size=11264 --fstype=xfs
 logvol /var/log/audit        --name=lv_var_log_audit  --vgname=vg_system --size=512   --fstype=xfs

--- a/kickstarts/partials/main/disk_layout.ks.erb
+++ b/kickstarts/partials/main/disk_layout.ks.erb
@@ -2,13 +2,13 @@
 zerombr
 clearpart       --all --drives=vda
 
-part pv.1             --ondrive=vda                   --size=<%= @target == "azure" ? "27648" : "32768" %>
+part pv.1             --ondrive=vda                   --size=<%= @target == "azure" ? "37888" : "43008" %>
 part /boot            --ondrive=vda                   --size=1024  --fstype=xfs
 part /var/www/miq_tmp --ondrive=vda                   --size=10240 --fstype=xfs --fsoptions="rw,noatime,nobarrier"
 
 volgroup vg_system           --pesize=4096 pv.1
 logvol /                     --name=lv_os             --vgname=vg_system --size=10752 --fstype=xfs<%= " --grow" if @target == "azure" %>
-logvol /var                  --name=lv_var            --vgname=vg_system --size=2048  --fstype=xfs
+logvol /var                  --name=lv_var            --vgname=vg_system --size=12288 --fstype=xfs
 logvol /var/log              --name=lv_var_log        --vgname=vg_system --size=11264 --fstype=xfs
 logvol /var/log/audit        --name=lv_var_log_audit  --vgname=vg_system --size=512   --fstype=xfs
 logvol /tmp                  --name=lv_tmp            --vgname=vg_system --size=1024  --fstype=xfs


### PR DESCRIPTION
This PR increases the `/` filesystem from 4.5GiB to 10GiB and the `/var` filesystem from 2GiB to 12GiB

The root filesystem change is needed so that upgrades can be performed by using `bin/update` as described in #219. In this case the new gems being installed in `/opt/rubies/ruby-2.3.1/lib/ruby/gems` were filling up the space on the root filesystem.  It should be noted that after upgrading the appliance, we can run `bundle clean --force` to remove old versions of updated gems and reclaim some space.

The `/var` filesystem change is needed so that we can use embedded ansible. Both the rpm and docker versions require more space. The rpm version has an explicit check which requires at least 10GiB of free space on the `/var` partition. We currently ignore that check [here](https://github.com/ManageIQ/manageiq/blob/5f3a0ce3a23f3f59d250269c06ac00c86582f006/lib/embedded_ansible.rb#L143), but it isn't checking without reason, so we would like to stop doing that.
Additionally the container version of embedded ansible (AWX) which is being developed in https://github.com/ManageIQ/manageiq/pull/16205 will need more space in `/var` for the docker daemon.

Adding WIP until my test build finishes.