### PR TITLE
Install ruby with --system so that bin files are easier to find

### DIFF
--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -7,14 +7,14 @@ mount -t tmpfs tmpfs /usr/local/src
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-ruby-install ruby 2.3.1 -- --disable-install-doc --enable-shared
+ruby-install --system ruby 2.3.1 -- --disable-install-doc --enable-shared
 
 # Free up tmpfs memory.
 umount /usr/local/src
 
-# Add the ruby binaries path to the PATH so we can find bundle and friends:
-ruby_bin_path=(/opt/rubies/ruby-2.3.1/bin)
-echo "export PATH=\$PATH:$ruby_bin_path" >> /etc/default/evm
+# Add the git based gem bin path to $PATH
+ruby_gem_path="$(gem env gemdir)/bin"
+echo "export PATH=\$PATH:$ruby_gem_path" >> /etc/default/evm
 
 cat /etc/default/evm
 


### PR DESCRIPTION
This also adds the `gem env gemdir` bin path to the $PATH using /etc/default/evm

This allows us to find bin files provided by git-based gems

This will allow the appliance console to work after the gem split.