### PR TITLE
Add /usr/local/bin to the PATH after installing ruby

### DIFF
--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -9,6 +9,9 @@ mount -t tmpfs tmpfs /usr/local/src
 # See: https://github.com/postmodern/ruby-install/issues/175
 ruby-install --system ruby 2.3.1 -- --disable-install-doc --enable-shared
 
+# ensure /usr/local/bin is on the path as this is where ruby, gem, and bundle will be installed
+export PATH=$PATH:/usr/local/bin
+
 # Free up tmpfs memory.
 umount /usr/local/src
 


### PR DESCRIPTION
Without this we're getting the following when trying to run gem during the kickstart process:

++ [18:11:21] gem env gemdir
/tmp/ks-script-Kv98jD: line 125: gem: command not found