### PR TITLE
Update to CentOS 7.4

### DIFF
--- a/config/base.tdl
+++ b/config/base.tdl
@@ -1,15 +1,15 @@
 <template>
-  <name>CentOS-7.3</name>
+  <name>CentOS-7.4</name>
   <os>
     <rootpw>ozrootpw</rootpw>
     <name>CentOS-7</name>
-    <version>3</version>
+    <version>4</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1611.iso</iso>
+      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1708.iso</iso>
     </install>
   </os>
-  <description>CentOS73 TDL meant to be used with custom kickstart for manageiq.</description>
+  <description>CentOS74 TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
     <size>66G</size>
   </disk>

--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -1,15 +1,15 @@
 <template>
-  <name>CentOS-7.2</name>
+  <name>CentOS-7.4</name>
   <os>
     <rootpw>ozrootpw</rootpw>
     <name>CentOS-7</name>
-    <version>2</version>
+    <version>4</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1511.iso</iso>
+      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1708.iso</iso>
     </install>
   </os>
-  <description>CentOS72 TDL meant to be used with custom kickstart for manageiq.</description>
+  <description>CentOS74 TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
     <size>61G</size>
   </disk>


### PR DESCRIPTION
Closes https://github.com/ManageIQ/manageiq-appliance/issues/137

I will put a follow up PR to use just 1 tdl file for all images. It's probably not worth keeping 2 files, just to save 5GB disk size. (As you can see in the diff, I forgot to update azure one when we went from 7.2 to 7.3!)

The new ISO is already on the build machine.