### PR TITLE
[GAPRINDASHVILI] Lock bundler to 1.15.4

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -6,7 +6,7 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
-gem install bundler -v ">=1.8.4"
+gem install bundler -v 1.15.4
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 


### PR DESCRIPTION
Due to issues we're running into with bundler 1.16, locking to 1.15.4 for now.