### PR TITLE
Run `bundle clean --force` after we `bundle install`

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -12,4 +12,5 @@ ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/
 
 pushd /var/www/miq/vmdb
   bundle install
+  bundle clean --force
 popd


### PR DESCRIPTION
This will remove any duplicate gems that we have that were installed
with the system ruby (for example, minitest).

This was causing the following warning when starting the appliance_console

```plain
WARN: Unresolved specs during Gem::Specification.reset:
      minitest (~> 5.1)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
```

/cc @JPrause 