### PR TITLE
Remove enable for docker service

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -11,8 +11,6 @@ systemctl enable cloud-ds-check
 
 systemctl enable memcached
 
-systemctl enable docker
-
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 


### PR DESCRIPTION
This is only needed when we are running the embedded ansible
role so we can do it from the worker