### PR TITLE
Add qpid_proton to bundle install

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -11,6 +11,6 @@ gem install bundler -v ">=1.8.4"
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 
 pushd /var/www/miq/vmdb
-  bundle install
+  bundle install --with qpid_proton
   bundle clean --force
 popd


### PR DESCRIPTION
EPEL currently has qpid-proton-c 0.17.0. With this version of RPM, it fails to compile qpid_proton gem (v0.18.1). Marking as WIP until 0.18.x becomes available in EPEL.  0.18.1 is currently in epel-testing and gem install works with that version.

cc @gberginc @Fryguy @chargio