### PR TITLE
Install 'mime-types' outside of bundle

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -14,3 +14,7 @@ pushd /var/www/miq/vmdb
   bundle install
   bundle clean --force
 popd
+
+# Install mime-types outside of bundle, needed by 'rest-client' gem when run under irb/automate
+# Run this command after 'bundle clean' so it won't be removed by 'bundle clean'
+gem install mime-types -v 2.6.1


### PR DESCRIPTION
It's needed to load `rest-client` in irb/automate.  For bundle, we override with local path 'mime-types-redirector'

https://bugzilla.redhat.com/show_bug.cgi?id=1518865