### PR TITLE
Use noop io scheduler by default

### DIFF
--- a/kickstarts/partials/main/bootloader.ks.erb
+++ b/kickstarts/partials/main/bootloader.ks.erb
@@ -1,9 +1,9 @@
 <% if @target == "ec2" || @target == "openstack" %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
+bootloader --location=mbr --driveorder=vda --append="elevator=noop crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
 <% elsif @target == "azure" %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+bootloader --location=mbr --driveorder=vda --append="elevator=noop crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
 <% elsif @target == "gce" %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0,38400n8"
+bootloader --location=mbr --driveorder=vda --append="elevator=noop crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0,38400n8"
 <% else %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0"
+bootloader --location=mbr --driveorder=vda --append="elevator=noop crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0"
 <% end %>


### PR DESCRIPTION
KB article from VMware which recommends the noop scheduler: https://kb.vmware.com/s/article/2011861

Instructions on how to set the default io scheduler from Red Hat: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/performance_tuning_guide/sect-red_hat_enterprise_linux-performance_tuning_guide-storage_and_file_systems-configuration_tools#sect-Red_Hat_Enterprise_Linux-Performance_Tuning_Guide-Configuration_tools-Setting_the_default_IO_scheduler

Wondering if we think we should only change this for VMware images or for all of them?

https://bugzilla.redhat.com/show_bug.cgi?id=1531088