### PR TITLE
Clear yarn cache

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -11,3 +11,6 @@ pushd /opt/manageiq/manageiq-ui-service
   yarn install --production
   yarn run build
 popd
+
+# Clean cache, will be populated again when yarn runs next time
+yarn cache clean


### PR DESCRIPTION
Clearing yarn cache reduces the uncompressed image size by ~800MB

Uncompressed 'master' images (hyperv, azure, etc.) are now so big that it exceeds rackspace size limit and not being uploaded there since February... We should/can probably clean up more, but starting with this easy one.