### PR TITLE
Remove non-existing "server-policy" yum group

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -32,7 +32,6 @@ reboot
 
 %packages
 @base --nodefaults
-@server-policy --nodefaults
 @development tools
 
 <%= render_partial "packages/includes" %>


### PR DESCRIPTION
"server-policy" yum group doesn't exist on CentOS 7.

Up until now, having that entry in kickstart didn't cause any issue. It logged:

`13:01:02,893 CRIT yum.YumBase: Warning: Group server-policy does not have any packages to install.`

and build continued. But now, the build prompts for yes/no and times out waiting for an answer.

![image](https://user-images.githubusercontent.com/12955530/39871771-e194329a-5433-11e8-8b53-739c651e57e8.png)
