### PR TITLE
Install ansible and python-boto for running ansible-playbook

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -126,3 +126,7 @@ cockpit-ssh
 cyrus-sasl
 cyrus-sasl-plain
 qpid-proton-c-devel
+
+# For ansible-playbook
+ansible
+python-boto


### PR DESCRIPTION
For https://github.com/ManageIQ/manageiq/pull/17564. Both packages are available in EPEL.

cc @Ladas