### PR TITLE
Update to node 8

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -6,6 +6,8 @@ repo --name=epel    --baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
 
 # repos to install packages not found in the os
 repo --name=centos-scl --baseurl=http://mirror.centos.org/centos/7/sclo/x86_64/rh/
+repo --name=nodesource --baseurl=https://rpm.nodesource.com/pub_8.x/el/7/x86_64/
+
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-compute-el7-x86_64/
 <% end %>

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -100,9 +100,6 @@ cloud-init
 
 wmi
 
-# bower; Service UI (in devel mode)
-npm
-
 <% if @target == "ovirt" %>
 ovirt-guest-agent
 glusterfs-fuse

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -1,5 +1,6 @@
 epel-release       # http://dl.fedoraproject.org/pub/epel/7/x86_64/epel-release-7-5.noarch.rpm
 centos-release-scl-rh
+nodesource-release
 
 createrepo
 freeipmi


### PR DESCRIPTION
This PR adds a repo(`https://rpm.nodesource.com/pub_8.x/el/7/x86_64/`) during build from which we can install an rpm (`nodesource-release`) which brings a repo file which allows us to install nodejs version 8.

This also removes npm because the new node package also provides `/usr/bin/npm`

```
[root@localhost vmdb]# rpm -qa | grep node
nodesource-release-el7-1.noarch
nodejs-8.11.3-1nodesource.x86_64
[root@localhost vmdb]# rpm -qa | grep npm
[root@localhost vmdb]# which npm
/usr/bin/npm
[root@localhost vmdb]# yum provides /usr/bin/npm
2:nodejs-8.11.3-1nodesource.x86_64 : JavaScript runtime
Repo        : nodesource
Matched from:
Filename    : /usr/bin/npm

1:npm-3.10.10-1.6.14.3.1.el7.x86_64 : Node.js Package Manager
Repo        : epel
Matched from:
Filename    : /usr/bin/npm
```

cc @himdel 
