### PR TITLE
Update vSphere ova

### DIFF
--- a/config/ova.json
+++ b/config/ova.json
@@ -5,6 +5,7 @@
   "rhevm_description": "ManageIQ",
   "rhevm_default_display_type": "1",
   "rhevm_os_descriptor": "RHEL7",
+  "vsphere_os_type": "centos64Guest",
   "vsphere_product_name": "ManageIQ",
   "vsphere_product_vendor_name": "ManageIQ",
   "vsphere_product_version": "master"

--- a/config/ova.json
+++ b/config/ova.json
@@ -5,8 +5,10 @@
   "rhevm_description": "ManageIQ",
   "rhevm_default_display_type": "1",
   "rhevm_os_descriptor": "RHEL7",
+  "vsphere_network_controller_type": "VmxNet3",
   "vsphere_os_type": "centos64Guest",
   "vsphere_product_name": "ManageIQ",
   "vsphere_product_vendor_name": "ManageIQ",
-  "vsphere_product_version": "master"
+  "vsphere_product_version": "master",
+  "vsphere_virtual_system_type": "vmx-10"
 }

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -102,12 +102,15 @@ EOF
 # Let's rebuild the ramfs with with base scsi drivers we need
 kversion=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
 ramfsfile="/boot/initramfs-$kversion.img"
-drivers="mptbase mptscsih mptspi"
 <% case @target
    when "azure", "hyperv" %>
-drivers="$drivers hv_storvsc hid_hyperv hv_netvsc hv_vmbus"
+drivers="mptbase mptscsih mptspi hv_storvsc hid_hyperv hv_netvsc hv_vmbus"
 <% when "ec2" %>
-drivers="$drivers xen-blkfront xen-netfront"
+drivers="mptbase mptscsih mptspi xen-blkfront xen-netfront"
+<% when "vsphere" %>
+drivers="mptspi vmw_pvscsi"
+<% else %>
+drivers="mptbase mptscsih mptspi"
 <% end %>
 /sbin/dracut --force --add-drivers "$drivers" $ramfsfile $kversion
 


### PR DESCRIPTION
A few changes for vSphere appliance image.

For https://bugzilla.redhat.com/show_bug.cgi?id=1429653:
- Changed hardware version to vmx-10 (was: vmx-7/vmx-8)
- Changed network to VmxNet3 (was: E1000)
- Added paravirtual drivers

I didn't make the default driver to be paravirtual in OVA (default: LSI Logic) as that will make the image not to work on Fusion 10. Since the drivers are now included in the image, anyone wanting to use paravirtual can just change the setting once imported to vSphere.

For https://bugzilla.redhat.com/show_bug.cgi?id=1614006:
- Set OS type to `centos64Guest` (requires imagefactory [c78579f](https://github.com/redhat-imaging/imagefactory/commit/c78579ff3e7e3ed5fa79fab912968381d486f608) or later). OS will show as `CentOS 4/5/6/7 (64-bit)` in vSphere and `CentOS 64-bit` in Fusion. This fixes https://github.com/ManageIQ/manageiq-appliance-build/issues/26 cc @abellotti 

I will update imagefactory on build machine once this is merged.