### PR TITLE
Update appliances to ruby 2.4.4

### DIFF
--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -7,7 +7,7 @@ mount -t tmpfs tmpfs /usr/local/src
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-ruby-install --system ruby 2.3.1 -- --disable-install-doc --enable-shared
+ruby-install --system ruby 2.4.4 -- --disable-install-doc --enable-shared
 
 # ensure /usr/local/bin is on the path as this is where ruby, gem, and bundle will be installed
 export PATH=$PATH:/usr/local/bin


### PR DESCRIPTION
@simaishi I just noticed this is still 2.3.1... figured we wanted 2.4.4 on master/hammer, right?  Are there other places that need to be bumped to match what's available downstream?