### PR TITLE
Move from apache module mod_auth_kerb to mod_auth_gssapi

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -69,6 +69,7 @@ c-ares
 ipa-client
 sssd-dbus
 mod_intercept_form_submit
+mod_auth_kerb
 mod_auth_gssapi
 mod_authnz_pam
 mod_lookup_identity

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -69,7 +69,7 @@ c-ares
 ipa-client
 sssd-dbus
 mod_intercept_form_submit
-mod_auth_kerb
+mod_auth_gssapi
 mod_authnz_pam
 mod_lookup_identity
 realmd


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1610127/stories/160659028

This PR is one of a set that will implement moving external authentication support from
the Apache module mod_auth_kerb to mod_auth_gssapi

Once all of the PRs are available I will remove the WIP flag