### PR TITLE
Add post compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Below are instructions on installing and configuring a virtual machine to genera
   yum install ruby
   yum install ruby-devel
   yum install zlib-devel
+  yum install zip unzip
 
   gem install trollop
   gem install fog

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -20,6 +20,10 @@ describe Build::Target do
     expect(described_class.new("openstack").file_extension).to eql "qc2"
   end
 
+  it "#compression_type" do
+    expect(described_class.new("openstack").compression_type).to eql nil
+  end
+
   it "#sort" do
     targets = [described_class.new("vsphere"), described_class.new("openstack")]
     expect(targets.sort.collect(&:name)).to eql %w(openstack vsphere)

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -1,17 +1,17 @@
 module Build
   class Target
-    ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension)
+    ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension, :compression_type)
 
     TYPES = {
-      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova'),
-      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova'),
-      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2'),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
-      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd'),
-      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box'),
-      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2'),
-      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz'),
-      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd'),
+      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil),
+      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova', nil),
+      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', nil),
+      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd', nil),
+      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil),
+      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
+      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil),
+      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', nil),
     }
 
     attr_reader :name
@@ -39,6 +39,10 @@ module Build
 
     def file_extension
       TYPES.fetch(name).file_extension
+    end
+
+    def compression_type
+      TYPES.fetch(name).compression_type
     end
 
     def <=>(other)

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -145,25 +145,28 @@ Dir.chdir(IMGFAC_DIR) do
       temp_file_uuid << uuid
     end
     $log.info "Built #{target} with final UUID: #{uuid}"
-    source = STORAGE_DIR.join("#{uuid}.body")
 
     FileUtils.mkdir_p(destination_directory)
     file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{manageiq_checkout.commit_sha}.#{target.file_extension}"
     destination = destination_directory.join(file_name)
 
-    case compression
-    when 'gzip'
-      $log.info `gzip -c #{source} > #{destination}.gz`
-      destination = destination.sub_ext(destination.extname + '.gz')
-    when 'zip'
-      $log.info `ln #{source} #{destination}`
-      Dir.chdir destination_directory do
-        $log.info `zip #{destination.basename.sub_ext('.zip')} #{destination.basename}`
+    Dir.chdir(STORAGE_DIR) do
+      FileUtils.mv("#{uuid}.body", file_name)
+
+      case compression
+      when 'gzip'
+        destination = destination.sub_ext(destination.extname + '.gz')
+        $log.info "Compressing #{file_name} to #{destination}"
+        $log.info `gzip -c #{file_name} > #{destination}`
+        FileUtils.rm_f(file_name)
+      when 'zip'
+        destination = destination.sub_ext('.zip')
+        $log.info "Compressing #{file_name} to #{destination}"
+        $log.info `zip -m -j #{destination} #{file_name}`
+      else
+        $log.info "Moving #{file_name} to #{destination}"
+        FileUtils.mv(file_name, destination)
       end
-      $log.info `rm #{destination}`
-      destination = destination.sub_ext('.zip')
-    else
-      $log.info `ln #{source} #{destination}`
     end
 
     if !File.exist?(destination)
@@ -173,8 +176,8 @@ Dir.chdir(IMGFAC_DIR) do
       if cli_options[:fileshare] && FILE_SERVER && File.size(destination)
         $log.info "Creating File server #{FILE_SERVER} directory #{file_rdu_dir} ..."
         $log.info `ssh #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER} mkdir -p #{file_rdu_dir}`
-        $log.info "Copying file #{file_name} to #{FILE_SERVER}:#{file_rdu_dir}/ ..."
-        $log.info `scp #{destination} #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER}:#{file_rdu_dir.join(file_name)}`
+        $log.info "Copying file #{destination} to #{FILE_SERVER}:#{file_rdu_dir}/ ..."
+        $log.info `scp #{destination} #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER}:#{file_rdu_dir}`
       end
     end
 
@@ -187,7 +190,7 @@ Dir.chdir(IMGFAC_DIR) do
       $log.info `qemu-img convert -f qcow2 -O qcow2 -o compat=0.10 -c #{STORAGE_DIR.join("#{target_image_uuid}.body")} #{source}`
       $log.info `mv #{source} #{destination}`
       if cli_options[:fileshare] && FILE_SERVER && File.size(destination)
-        $log.info `scp #{destination} #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER}:#{file_rdu_dir.join(file_name)}`
+        $log.info `scp #{destination} #{FILE_SERVER_ACCOUNT}@#{FILE_SERVER}:#{file_rdu_dir}`
       end
     end
 

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -106,6 +106,7 @@ Dir.chdir(IMGFAC_DIR) do
   targets.sort.reverse.each do |target|
     imgfac_target = target.imagefactory_type
     ova_format    = target.ova_format
+    compression   = target.compression_type
     $log.info "Building for #{target}:"
 
     tdl_name = target.name == "azure" ? "base_azure.tdl" : "base.tdl"
@@ -149,7 +150,21 @@ Dir.chdir(IMGFAC_DIR) do
     FileUtils.mkdir_p(destination_directory)
     file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{manageiq_checkout.commit_sha}.#{target.file_extension}"
     destination = destination_directory.join(file_name)
-    $log.info `mv #{source} #{destination}`
+
+    case compression
+    when 'gzip'
+      $log.info `gzip -c #{source} > #{destination}.gz`
+      destination = destination.sub_ext(destination.extname + '.gz')
+    when 'zip'
+      $log.info `ln #{source} #{destination}`
+      Dir.chdir destination_directory do
+        $log.info `zip #{destination.basename.sub_ext('.zip')} #{destination.basename}`
+      end
+      $log.info `rm #{destination}`
+      destination = destination.sub_ext('.zip')
+    else
+      $log.info `ln #{source} #{destination}`
+    end
 
     if !File.exist?(destination)
       $log.warn "Cannot find the target file #{destination}"


### PR DESCRIPTION
We now need to compress some of the images as the image size is growing... This PR is adding an optional post-build compression support, taken from Geert's https://github.com/ManageIQ/manageiq-appliance-build/pull/167 with a few changes:

- Don't use hard links when compressing/moving image files as source and destination could be on different devices
- Delete original file after compression for gzip
- Don't pass file_name for scp target as file_name will be different for compressed images