### PR TITLE
Compress Azure, HyperV and EC2 images

### DIFF
--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -6,12 +6,12 @@ module Build
       'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil),
       'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova', nil),
       'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', nil),
-      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd', nil),
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip'),
+      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip'),
       'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil),
       'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
       'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil),
-      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', nil),
+      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip'),
     }
 
     attr_reader :name


### PR DESCRIPTION
Azure, HyperV and EC2 images are not compressed during imagefactory build. zip compressing the images so the image size will be comparable to other images.

@adahms It might affect documentation, so fyi...  This is upstream only change for now, and will go to Gaprindashvili and later branches.