### PR TITLE
Set commit_sha just once

### DIFF
--- a/scripts/git_checkout.rb
+++ b/scripts/git_checkout.rb
@@ -10,13 +10,15 @@ module Build
     end
 
     def commit_sha
-      long_sha =
-        if ref == "master"
-          ls_remote_sha("master")
-        else
-          ls_remote_sha(dereferenced_tag) || ls_remote_sha(ref)
-        end
-      long_sha.to_s[0, 10]
+      @commit_sha ||= begin
+        long_sha =
+          if ref == "master"
+            ls_remote_sha("master")
+          else
+            ls_remote_sha(dereferenced_tag) || ls_remote_sha(ref)
+          end
+        long_sha.to_s[0, 10]
+      end
     end
 
     def branch


### PR DESCRIPTION
We're getting new git sha every time commit_sha is called. This causes appliance file names to be different for the same nightly build run if a commit happens when build is running:

manageiq-openstack-hammer-201810050800-1310fd6601.qc2
manageiq-ovirt-hammer-201810050800-28a765dd38.ova

This only affects file names and contents are ok as all kickstart files are generated at the same time.

Diff will be easier with [?w=1](https://github.com/ManageIQ/manageiq-appliance-build/pull/290/files?w=1)