### PR TITLE
Add vspk python module for Nuage

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -73,6 +73,8 @@ export RAILS_USE_MEMORY_STORE="true"
 
 <%= render_partial "post/ovirt_ansible" %>
 
+<%= render_partial "post/python_modules" %>
+
 <%= render_partial "post/ruby_install" %>
 
 <%= render_partial "post/bundler" %>

--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -1,0 +1,4 @@
+yum install -y python-pip
+
+# For Nuage
+pip install vspk==5.3.2


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1630801

Bambou (which is also listed in the BZ) is a dependency of vspk.