### PR TITLE
Add seeding ansible runner galaxy roles

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -82,6 +82,8 @@ export RAILS_USE_MEMORY_STORE="true"
 # needs to run *after* post/bundler
 <%= render_partial "post/ui_compile" %>
 
+<%= render_partial "post/rake_tasks" %>
+
 # appliance_root="/opt/manageiq/manageiq-appliance" -- in post/source_setup partial
 $appliance_root/manageiq-setup.sh
 

--- a/kickstarts/partials/post/rake_tasks.ks.erb
+++ b/kickstarts/partials/post/rake_tasks.ks.erb
@@ -1,0 +1,4 @@
+pushd /var/www/miq/vmdb
+  # Seed ansible runner galaxy roles
+  rake evm:ansible_runner:seed
+popd


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1649378

Naming the partial as `rake_tasks` so future tasks can be added to the same partial, rather than creating separate file for each...