### PR TITLE
Use Optimist

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Below are instructions on installing and configuring a virtual machine to genera
   yum install zlib-devel
   yum install zip unzip
 
-  gem install trollop
+  gem install optimist
   gem install fog
   ```
 

--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "trollop"
+gem "optimist"
 
 group :development, :test do
   gem "rake"

--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    optimist (3.0.0)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -16,15 +17,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    trollop (2.1.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  optimist
   rake
   rspec
-  trollop
 
 BUNDLED WITH
    1.10.6

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'trollop'
+require 'optimist'
 require_relative 'target'
 
 module Build
@@ -26,7 +26,7 @@ module Build
       upload_desc    = "Upload appliance builds to the website"
       only_desc      = "Build only specific image types.  Example: --only ovirt openstack.  Defaults to all images."
 
-      @options = Trollop.options(args) do
+      @options = Optimist.options(args) do
         banner "Usage: build.rb [options]"
         opt :appliance_ref, git_ref_desc,   :type => :string,  :short => "a", :default => DEFAULT_REF
         opt :appliance_url, appliance_desc, :type => :string,  :short => "A", :default => APPLIANCE_URL
@@ -55,10 +55,10 @@ module Build
       [:manageiq_ref, :appliance_ref, :build_ref, :sui_ref].each do |ref|
         options[ref] = (options[:reference] || options[ref]).to_s.strip
       end
-      Trollop.die(:manageiq_ref, git_ref_desc) if options[:manageiq_ref].to_s.empty?
+      Optimist.die(:manageiq_ref, git_ref_desc) if options[:manageiq_ref].to_s.empty?
 
       # 'release' build requires non DEFAULT_REF reference
-      Trollop.die(:manageiq_ref, git_ref_desc) if options[:type] == "release" && options[:manageiq_ref] == DEFAULT_REF
+      Optimist.die(:manageiq_ref, git_ref_desc) if options[:type] == "release" && options[:manageiq_ref] == DEFAULT_REF
 
       self
     end


### PR DESCRIPTION
`Trollop` is a deprecated gem, and has been renamed/replaced by [`Optimist`](https://github.com/ManageIQ/optimist).

Since the changes made in this PR has no affect on the resulting appliance dependencies, this should be fine to be merged without needing to update other repos in the ManageIQ organization.


Links
-----

* Org search of current usage of old gem (hides some irrelevant repos):  [search](https://github.com/search?l=&q=Trollop+repo%3AManageIQ%2Fmanageiq+repo%3AManageIQ%2Fmanageiq-release+repo%3AManageIQ%2Fmanageiq-appliance_console+repo%3AManageIQ%2Fmanageiq-appliance-build+repo%3AManageIQ%2Fmanageiq-api+repo%3AManageIQ%2Fmanageiq-providers-vmware+repo%3AManageIQ%2Fhttpd_configmap_generator+repo%3AManageIQ%2Fguides&type=Code)