### PR TITLE
Temporarily downgrade qpid proton c library

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -10,6 +10,9 @@ gem install bundler -v ">=1.8.4"
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 
+# TEMPORARY FIX
+yum -y downgrade qpid-proton-c-0.19.0-1.el7.centos qpid-proton-c-devel-0.19.0-1.el7.centos
+
 pushd /var/www/miq/vmdb
   bundle install --with qpid_proton
   bundle clean --force


### PR DESCRIPTION
EPEL has updated qpid-proton-c to 0.26.0 recently. But this version doesn't seem to be compatible with gem version we lock to (0.22.0) and "bundle install" is currently failing for both `master` and `hammer` branches on appliances:

```
Installing qpid_proton 0.22.0 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
......
cproton.c: In function ‘_wrap_pn_selectables’:
cproton.c:16896:3: error: unknown type name ‘pn_selectables_t’
......
An error occurred while installing qpid_proton (0.22.0), and Bundler cannot continue.
```

To get back to working state quickly, temporarily downgrading the c library package to 0.19.0 that's available in ManageIQ copr repo and is known to work.

@Fryguy @carbonin please reivew

@gberginc @miha-plesko Just the other day, we discussed how updating the qpid_proton version could be a pain, but now we have found out NOT updating is causing a problem too.  I think downgrading a rpm package isn't best practice and would like to avoid if possible.  Can we look into updating the gem version?
