### PR TITLE
Remove temporary workaround to downgrade qpid-proton-c

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -10,9 +10,6 @@ gem install bundler -v ">=1.8.4"
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 
-# TEMPORARY FIX
-yum -y downgrade qpid-proton-c-0.19.0-1.el7.centos qpid-proton-c-devel-0.19.0-1.el7.centos
-
 pushd /var/www/miq/vmdb
   bundle install --with qpid_proton
   bundle clean --force


### PR DESCRIPTION
qpid_proton gem version is being updated to 0.26.0, so no need to downgrade c library package any more.

Reverting https://github.com/ManageIQ/manageiq-appliance-build/pull/307
Depends on https://github.com/ManageIQ/manageiq/pull/18544