### PR TITLE
Exclude specific -firmware packages only

### DIFF
--- a/kickstarts/partials/packages/excludes.ks.erb
+++ b/kickstarts/partials/packages/excludes.ks.erb
@@ -6,7 +6,10 @@
 # We don't need any firmware files. We always run as a virtual appliance, and
 # none of the virtual hardware devices implement by any of the major hypervisor
 # vendors needs firmware.
--*-firmware
+# Since 'linux-firmware' is required by kernel, exclude everything but that.
+-aic*-firmware
+-ivtv-firmware
+-iwl*-firmware
 
 # Misc other things we do not need.
 -gcc-gfortran


### PR DESCRIPTION
We're currently excluding `*-firmware` packages. But `linux-firmware` is required by kernel and installed. Instead of excluding `*-firmware`, excluding all firmware that's not `linux-firmware` to avoid possible package conflict during install.

```
Mar 11 21:41:09 localhost packaging[1202]: deselect package *-firmware
...
Mar 11 21:41:14 localhost yum[1202]: TSINFO: Marking linux-firmware-20180911-69.git85c5d90.el7.noarch
as install for kernel-3.10.0-957.5.1.el7.x86_64
```
Verified only `linux-firmware` is present on the machine by running a build with this change.
