### PR TITLE
[WIP] Enable NetworkManager

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -16,5 +16,3 @@ ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 
 # Create the journal directory to enable persistant logging
 mkdir /var/log/journal
-
-systemctl disable NetworkManager


### PR DESCRIPTION
Running `ifup eth0` without it complains that it isn't running

Seems that now we're at the point @kbrock was suggesting in
https://github.com/ManageIQ/manageiq-appliance-build/pull/66
and we need NetworkManager enabled to get an ip address

@simaishi this should fix your issue with the downstream appliances not having an IP address, but I'm not sure what it will do to the upstream ones .... It should be fine .. right?