### PR TITLE
[WIP] Bind mount the log dir instead of using a symlink

### DIFF
--- a/kickstarts/partials/post/source_setup.ks.erb
+++ b/kickstarts/partials/post/source_setup.ks.erb
@@ -20,8 +20,8 @@ ln -vs $vmdb_root $manageiq_root
 
 # Replace the log directory with the larger logvol
 mkdir -p /var/log/manageiq
-rm -rf $vmdb_root/log
-ln -vs /var/log/manageiq $vmdb_root/log
+touch /var/log/manageiq/.keep
+mount --bind /var/log/manageiq $vmdb_root/log
 
 <%= git_checkout(@sui_checkout, "$sui_root") %>
 


### PR DESCRIPTION
Using a symlink to the log directory leads to a dirty git tree, if we
add a log/.keep and also touch /var/log/manageiq/.keep we can bind mount
the /var/log/manageiq directory without dirtying the git status and also
remove the issues with not having a log/ directory in any of the repos
necessitating a bin/setup script to get tests to run.

TODO:

- [ ] Add the bind mount to /etc/fstab so the log dir is mounted on boot