### PR TITLE
[HAMMER] Update to ruby 2.4.6

### DIFF
--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -7,7 +7,7 @@ mount -t tmpfs tmpfs /usr/local/src
 # Once the --update option is available, we could ask
 # ruby-install to "learn" what new rubies are available
 # See: https://github.com/postmodern/ruby-install/issues/175
-ruby-install --system ruby 2.4.5 -- --disable-install-doc --enable-shared
+ruby-install --system ruby 2.4.6 -- --disable-install-doc --enable-shared
 
 # ensure /usr/local/bin is on the path as this is where ruby, gem, and bundle will be installed
 export PATH=$PATH:/usr/local/bin


### PR DESCRIPTION
2.4.6 includes multiple CVE fixes:
https://www.ruby-lang.org/en/news/2019/03/05/multiple-vulnerabilities-in-rubygems/

This is `hammer` only change, as I will be updating `master` to 2.5.x