### PR TITLE
Add cockpit packages and changes to allow it to run by default

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -26,6 +26,7 @@ ansible-runner
 chrony
 cifs-utils
 cmake                            # For rugged gem
+cockpit
 cronie
 docker                           # For embedded ansible support
 http-parser                      # libhttp_parser.so.2 needed by nodejs

--- a/kickstarts/partials/post/firewalld.ks.erb
+++ b/kickstarts/partials/post/firewalld.ks.erb
@@ -16,3 +16,4 @@ firewall-offline-cmd --zone=manageiq --add-service=https
 firewall-offline-cmd --zone=manageiq --add-service=ssh
 firewall-offline-cmd --zone=manageiq --add-service=postgresql
 firewall-offline-cmd --zone=manageiq --add-service=dhcpv6-client
+firewall-offline-cme --zone=manageiq --add-service=cockpit

--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -11,6 +11,8 @@ systemctl enable cloud-ds-check
 
 systemctl enable memcached
 
+systemctl enable cockpit.socket
+
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 


### PR DESCRIPTION
This should replace a good amount of the system management
we do in the appliance console

Requires https://github.com/ManageIQ/manageiq-appliance/pull/239 for cockpit to work