### PR TITLE
pip install django for ansible credential upgrades

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -5,3 +5,6 @@ pip install vspk==5.3.2
 
 # For Lenovo
 pip install pylxca==2.1.1
+
+# For upgrading embedded ansible credentials
+pip install django==1.11.16


### PR DESCRIPTION
This is needed for a python script we use to migrate credentials
which are encrypted using the awx encryption algorithm which relies
on some django utilities

If we change that migration to vendor the django utilities or
rewrite the whole thing in ruby before we release it then this
can be removed.