### PR TITLE
Do not use unrecommended mount option nobarrier

### DIFF
--- a/kickstarts/partials/main/disk_layout.ks.erb
+++ b/kickstarts/partials/main/disk_layout.ks.erb
@@ -4,7 +4,7 @@ clearpart       --all --drives=vda
 
 part pv.1             --ondrive=vda                   --size=<%= @target == "azure" ? "37888" : "43008" %>
 part /boot            --ondrive=vda                   --size=1024  --fstype=xfs
-part /var/www/miq_tmp --ondrive=vda                   --size=10240 --fstype=xfs --fsoptions="rw,noatime,nobarrier"
+part /var/www/miq_tmp --ondrive=vda                   --size=10240 --fstype=xfs --fsoptions="rw,noatime"
 
 volgroup vg_system           --pesize=4096 pv.1
 logvol /                     --name=lv_os             --vgname=vg_system --size=10752 --fstype=xfs<%= " --grow" if @target == "azure" %>


### PR DESCRIPTION
Starting with RHEL6 the mount option nobarrier was no longer recommended.
Starting with RHEL8 the mount option nobarrier was no longer supported. The mount
command fails on RHEL8 if the nobarrier option is provided.

This PR removes the unrecommended nobarrier mount option.

This will be more important once we can build upstream against a CentOS version 8.