### PR TITLE
Temporary fix for asset compile error on Azure

### DIFF
--- a/config/base.json.azure
+++ b/config/base.json.azure
@@ -1,0 +1,4 @@
+{
+  "generate_icicle": false,
+  "oz_overrides" : "{'libvirt': {'memory': 6144}}"
+}

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -110,6 +110,7 @@ Dir.chdir(IMGFAC_DIR) do
     $log.info "Building for #{target}:"
 
     tdl_name = target.name == "azure" ? "base_azure.tdl" : "base.tdl"
+    base_file   = CFG_DIR.join("base.json.azure") if target.name == "azure"
     tdl_file = CFG_DIR.join(tdl_name)
     $log.info "Using inputs: puddle: #{puddle}, build_label: #{build_label}"
     $log.info "              tdl_file: #{tdl_file}, ova_file: #{ova_file}."


### PR DESCRIPTION
Compiling assets can fail on Azure, running out of memory during build. While I investigate the permanent fix, putting a temporary fix to increase libvirt memory.