### PR TITLE
Increase libvirt memory to 4GB to reduce build time

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -1,4 +1,4 @@
 {
   "generate_icicle": false,
-  "oz_overrides" : "{'libvirt': {'memory': 2048}}"
+  "oz_overrides" : "{'libvirt': {'memory': 4096}}"
 }


### PR DESCRIPTION
2GB just isn't enough... compiling assets could take up to 4GB at times.