### PR TITLE
Install python modules required for embedded ansible credentials

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -49,6 +49,7 @@ openslp-devel                    # build requires
 postgresql                       # appliance section
 postgresql-devel                 # for pg gem
 postgresql-server                # appliance section
+python-devel                     # for building python modules in post
 repmgr10
 smem                             # for PSS, USS with forked processes
 screen

--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -5,3 +5,130 @@ pip install vspk==5.3.2
 
 # For Lenovo
 pip install pylxca==2.1.1
+
+# For embedded ansible
+pip install virtualenv
+
+mkdir -p /var/lib/manageiq/
+pushd /var/lib/manageiq
+  virtualenv venv
+  source venv/bin/activate
+
+  cat > requirements.txt << EOF
+adal==1.2.1
+apache-libcloud==2.5.0
+appdirs==1.4.3
+applicationinsights==0.11.1
+argcomplete==1.9.4
+asn1crypto==0.24.0
+azure-cli-core==2.0.35
+azure-cli-nspkg==3.0.2
+azure-common==1.1.11
+azure-graphrbac==0.40.0
+azure-keyvault==1.0.0a1
+azure-mgmt-authorization==0.51.1
+azure-mgmt-batch==5.0.1
+azure-mgmt-cdn==3.0.0
+azure-mgmt-compute==4.4.0
+azure-mgmt-containerinstance==1.4.0
+azure-mgmt-containerregistry==2.0.0
+azure-mgmt-containerservice==4.4.0
+azure-mgmt-cosmosdb==0.5.2
+azure-mgmt-devtestlabs==3.0.0
+azure-mgmt-dns==2.1.0
+azure-mgmt-hdinsight==0.1.0
+azure-mgmt-keyvault==1.1.0
+azure-mgmt-loganalytics==0.2.0
+azure-mgmt-marketplaceordering==0.1.0
+azure-mgmt-monitor==0.5.2
+azure-mgmt-network==2.3.0
+azure-mgmt-nspkg==2.0.0
+azure-mgmt-rdbms==1.4.1
+azure-mgmt-redis==5.0.0
+azure-mgmt-resource==2.1.0
+azure-mgmt-servicebus==0.5.3
+azure-mgmt-sql==0.10.0
+azure-mgmt-storage==3.1.0
+azure-mgmt-trafficmanager==0.50.0
+azure-mgmt-web==0.41.0
+azure-nspkg==2.0.0
+azure-storage==0.35.1
+backports.ssl-match-hostname==3.5.0.1
+bcrypt==3.1.4
+boto==2.47.0
+boto3==1.6.2
+botocore==1.9.3
+cachetools==3.0.0
+certifi==2018.1.18
+cffi==1.11.5
+chardet==3.0.4
+colorama==0.3.9
+cryptography==2.6.1
+decorator==4.2.1
+deprecation==2.0
+docutils==0.14
+dogpile.cache==0.6.5
+google-auth==1.6.2
+humanfriendly==4.8
+idna==2.6
+ipaddress==1.0.19
+iso8601==0.1.12
+isodate==0.6.0
+Jinja2==2.10.1
+jmespath==0.9.3
+jsonpatch==1.21
+jsonpointer==2.0
+keystoneauth1==3.11.2
+knack==0.3.3
+lxml==4.1.1
+MarkupSafe==1.1.1
+monotonic==1.4
+msrest==0.6.1
+msrestazure==0.5.0
+munch==2.2.0
+ncclient==0.6.3
+netaddr==0.7.19
+netifaces==0.10.6
+ntlm-auth==1.0.6
+oauthlib==2.0.6
+openstacksdk==0.23.0
+os-service-types==1.2.0
+ovirt-engine-sdk-python==4.2.4
+packaging==17.1
+paramiko==2.4.2
+pbr==3.1.1
+pexpect==4.6.0
+psutil==5.4.3
+ptyprocess==0.5.2
+pyasn1==0.4.2
+pyasn1-modules==0.2.3
+pycparser==2.18
+Pygments==2.2.0
+PyJWT==1.6.0
+pykerberos==1.2.1
+PyNaCl==1.2.1
+pyOpenSSL==17.5.0
+pyparsing==2.2.0
+python-dateutil==2.6.1
+pyvmomi==6.5
+pywinrm==0.3.0
+PyYAML==5.1
+requests==2.20.0
+requests-credssp==0.1.0
+requests-kerberos==0.12.0
+requests-ntlm==1.1.0
+requests-oauthlib==0.8.0
+requestsexceptions==1.4.0
+s3transfer==0.1.13
+selectors2==2.0.1
+six==1.11.0
+stevedore==1.28.0
+tabulate==0.7.7
+urllib3==1.24.3
+xmltodict==0.11.0
+EOF
+
+  pip install -r requirements.txt
+
+  deactivate
+popd


### PR DESCRIPTION
We install these into a new venv so that we don't conflict with
appliance python packages.

This list is taken directly from
https://raw.githubusercontent.com/ansible/awx/c7bb0f10e10476e10df8a7e7b26732eb60958ca1/requirements/requirements_ansible.txt
which is the result of resolving the dependencies from
https://github.com/ansible/awx/blob/c7bb0f10e10476e10df8a7e7b26732eb60958ca1/requirements/requirements_ansible.in

I feel like taking the resolved file first is safer since pip doesn't
do true dependency resolution (pypa/pip#988)

Replacement for https://github.com/ManageIQ/manageiq-appliance-build/pull/340

Looking for input on places to put the list of packages. I felt like people wouldn't go looking for this list in `manageiq-appliance`, but it needs to live on disk somewhere ...

I could put it in manageiq core, but this seemed like a better place to start since it's really a build-time concern.

https://bugzilla.redhat.com/show_bug.cgi?id=1734129