### PR TITLE
Add yarn available-languages to ui-service build

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -8,7 +8,7 @@ popd
 
 # Service UI
 pushd /opt/manageiq/manageiq-ui-service
-  yarn install --production
+  yarn install
   yarn run available-languages
   yarn run build
 popd

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -9,6 +9,7 @@ popd
 # Service UI
 pushd /opt/manageiq/manageiq-ui-service
   yarn install --production
+  yarn run available-languages
   yarn run build
 popd
 


### PR DESCRIPTION
As a part of ui-service build, we need to run

    `yarn available-languages`

That command will update list of available languages and put them into `available_languages.json` file. That json file determines which language choices will be presented to the user during login.

The reason we need it in the build process is that there's a mechanism for restricting the list of presented languages to the user by creating a file `supported_languages.json`. When this file exists, `yarn available-languages` includes only languages that are explicitly specified in the supported list.

We do have `supported_languages.json` in CFME build, but currently that list is not being applied, because we lack this one step in the build process.

https://bugzilla.redhat.com/show_bug.cgi?id=1743734

@miq-bot add_label ivanchuk/yes