### PR TITLE
Add option to use a different npm registry for yarn

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,5 +1,9 @@
 npm install -g yarn
 
+<% if File.exist?(@build_base.join(KS_PART_DIR, "post", "npm_registry.ks.erb")) %>
+  <%= render_partial "post/npm_registry" %>
+<% end %>
+
 pushd /var/www/miq/vmdb
   rake update:ui
   RAILS_ENV=production rake evm:compile_assets
@@ -15,3 +19,7 @@ popd
 
 # Clean cache, will be populated again when yarn runs next time
 yarn cache clean
+
+<% if File.exist?(@build_base.join(KS_PART_DIR, "post", "npm_registry_cleanup.ks.erb")) %>
+  <%= render_partial "post/npm_registry_cleanup" %>
+<% end %>


### PR DESCRIPTION
Add an option to override npm registry. This will be no-op if npm_registry/npm_registry_cleanup don't exist on the build machine.

Example npm_registry.erb.ks
```
yarn config set registry <your registry>
find ${repos_root} -name yarn.lock -exec sed -i 's|https://registry.yarnpkg.com|<your registry>|g' {} +
find $(gem env gemdir)/bundler -name yarn.lock -exec sed -i 's|https://registry.yarnpkg.com|<your registry>|g' {} +
```

This will cover `yarn install` which is what our UI uses and takes care of all packages except for `yarn`. I will create a follow up PR for `npm install` which will take care of `yarn`.