### PR TITLE
Update Google Compute Engine packages

### DIFF
--- a/kickstarts/partials/post/gce.ks.erb
+++ b/kickstarts/partials/post/gce.ks.erb
@@ -8,7 +8,7 @@ network_enabled=false
 setup=false
 EOF
 
-yum install -y google-compute-engine google-compute-engine-init google-config
+yum install -y google-compute-engine python-google-compute-engine
 
 # Delete cfg files used here, so default cfg file will be created on next boot
 rm -f /etc/default/instance_configs.cfg*


### PR DESCRIPTION
Currently the build isn't installing packages needed for Google Compute Engine (which prevents users from ssh'ing to the machine) due to errors:

```
yum install -y google-compute-engine google-compute-engine-init google-config

...

Transaction check error:
  file /etc/dhcp/dhclient.d/google_hostname.sh conflicts between attempted installs of google-compute-engine-1:20190801.00-g1.el7.noarch and google-config-2.1.2-0.1484936429.el7.x86_64
  file /etc/rsyslog.d/90-google.conf conflicts between attempted installs of google-compute-engine-1:20190801.00-g1.el7.noarch and google-config-2.1.2-0.1484936429.el7.x86_64
  file /etc/sysctl.d/11-gce-network-security.conf conflicts between attempted installs of google-compute-engine-1:20190801.00-g1.el7.noarch and google-config-2.1.2-0.1484936429.el7.x86_64
  file /usr/lib/systemd/system/google-accounts-daemon.service conflicts between attempted installs of google-compute-engine-init-2.1.2-0.1488484921.el7.x86_64 and google-compute-engine-1:20190801.00-g1.el7.noarch
  file /usr/lib/systemd/system/google-clock-skew-daemon.service conflicts between attempted installs of google-compute-engine-init-2.1.2-0.1488484921.el7.x86_64 and google-compute-engine-1:20190801.00-g1.el7.noarch
  file /usr/lib/systemd/system/google-instance-setup.service conflicts between attempted installs of google-compute-engine-init-2.1.2-0.1488484921.el7.x86_64 and google-compute-engine-1:20190801.00-g1.el7.noarch
  file /usr/lib/systemd/system/google-shutdown-scripts.service conflicts between attempted installs of google-compute-engine-init-2.1.2-0.1488484921.el7.x86_64 and google-compute-engine-1:20190801.00-g1.el7.noarch
  file /usr/lib/systemd/system/google-startup-scripts.service conflicts between attempted installs of google-compute-engine-init-2.1.2-0.1488484921.el7.x86_64 and google-compute-engine-1:20190801.00-g1.el7.noarch

...

```

This is due to some packages being deprecated, so updating to the current packages.

I did confirm the packages can be installed without error with this change, and I don't think any other changes are needed. However I don't currently have an environment to test this out and confirm that. Since this will at least fix issue partially if not fully, I'm putting PR out anyway...