### PR TITLE
Fix optional kickstart partial handling and add support for "npm install"

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,8 +1,6 @@
 npm install -g yarn
 
-<% if File.exist?(@build_base.join(KS_PART_DIR, "post", "npm_registry.ks.erb")) %>
-  <%= render_partial "post/npm_registry" %>
-<% end %>
+<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry.ks.erb") %>
 
 pushd /var/www/miq/vmdb
   rake update:ui
@@ -20,6 +18,4 @@ popd
 # Clean cache, will be populated again when yarn runs next time
 yarn cache clean
 
-<% if File.exist?(@build_base.join(KS_PART_DIR, "post", "npm_registry_cleanup.ks.erb")) %>
-  <%= render_partial "post/npm_registry_cleanup" %>
-<% end %>
+<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry_cleanup.ks.erb") %>

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,6 +1,8 @@
+<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry.ks.erb") %>
+
 npm install -g yarn
 
-<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry.ks.erb") %>
+<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry_yarn.ks.erb") %>
 
 pushd /var/www/miq/vmdb
   rake update:ui

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -55,5 +55,10 @@ module Build
       file = Productization.file_for(@build_base, "#{KS_PART_DIR}/#{filename}.ks.erb")
       ERB.new(File.read(file)).result(binding)
     end
+
+    def render_partial_if_exist(filename)
+      return unless File.file?(filename)
+      ERB.new(File.read(filename)).result(binding)
+    end
   end
 end


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-appliance-build/pull/345 worked only partially - when `--local` is used and when `bin/kickstart_build.rb` is used. For nightly build, manageiq-appliance-build is cloned to a different directory and kickstart files from there are used. Since `@build_base` is different in those cases, my previous PR didn't work.

I'm changing to take optional kickstart partials from a different location. Settings like npm registry will be per build machine setting, not per build/branch setting, so it actually makes sense the files live somewhere else that all builds can access.

For the new `render_partial_if_exist` method, use of `Productization.file_for` isn't needed as we can commit all files for downstream builds and this new method won't be used there.

Also added optionally using an override for "npm install" as this was previously possible only for "yarn install".