### PR TITLE
Drop OVA for oVirt

### DIFF
--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -4,7 +4,7 @@ module Build
 
     TYPES = {
       'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil),
-      'ovirt'     => ImagefactoryMetadata.new('rhevm', 'rhevm', 'ova', nil),
+      'ovirt'     => ImagefactoryMetadata.new('rhevm', nil, 'qc2', 'qemu-qcow2'),
       'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil),
       'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip'),
       'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip'),


### PR DESCRIPTION
We started creating 2 formats for oVirt (ova and qcow2) in https://github.com/ManageIQ/manageiq-appliance-build/pull/193 because oVirt 3.x supported ova only and 4.1 supported qcow2 only.

The currently supported versions of oVirt (4.x) all support qcow2, so we no longer need to build 2 different formats.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1740898