### PR TITLE
Configure network adapters during kickstart

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -91,13 +91,20 @@ $appliance_root/manageiq-setup.sh
 
 <%= render_partial "post/db_init" %>
 
-# make sure we have the device name in all ifcfg-* files
-ls /etc/sysconfig/network-scripts/ifcfg-* | while read FILE
-do
-  # parse the device name from FILE
-  DEVICE=${FILE##*-}
-  grep -q 'DEVICE=' $FILE || echo "DEVICE=$DEVICE" >> $FILE
-done
+# During the image build, dracut sets up ifcfg-en<whatever> for the device.
+# On the appliances we expect eth0, so remove all the ifcfg-en<whatever> device configurations 
+# and write a config for eth0 allowing the 'network' service to come up cleanly.
+rm -f /etc/sysconfig/network-scripts/ifcfg-en*
+
+cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
+DEVICE=eth0
+BOOTPROTO=dhcp
+ONBOOT=yes
+TYPE=Ethernet
+USERCTL=no
+NM_CONTROLLED=no
+DEFROUTE=yes
+EOF
 
 # Disable zeroconfig to allow access to meta-data service by cloud-init
 cat >> /etc/sysconfig/network << EOF

--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -8,6 +8,7 @@ systemctl enable evminit
 systemctl enable memcached
 systemctl enable miqtop
 systemctl enable miqvmstat
+systemctl enable network
 systemctl enable postfix
 
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console


### PR DESCRIPTION
- Ensure network service is enabled
- Remove invalid configurations for adapters en*
- Add a config for eth0

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1755398