### PR TITLE
Add activesupport to Gemfile

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem "activesupport"
 gem "optimist"
 gem "rest-client", "~> 2.1"
 


### PR DESCRIPTION
Updated our build machine for https://github.com/ManageIQ/manageiq-appliance-build/pull/352 and noticed activesupport isn't there, so adding to Gemfile.