### PR TITLE
Fix file extension for devel filename

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -140,7 +140,7 @@ module Build
 
     def devel_filename(appliance_name)
       name = appliance_name.split("-")
-      (name[0..1] << "devel").join("-") + File.extname(appliance_name)
+      (name[0..1] << "devel").join("-") + name[-1].sub(/\h*/, '')
     end
 
     def nightly_filename(appliance_name)


### PR DESCRIPTION
Fix devel_filename generation as GCE file name has two `.` for extension: `manageiq-gce-master-<date>-<sha>.tar.gz`

 https://github.com/ManageIQ/manageiq-appliance-build/pull/357#discussion_r331268214