### PR TITLE
Clean yarn cache after OpsUI build

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -10,6 +10,9 @@ pushd /var/www/miq/vmdb
   rake evm:compile_sti_loader
 popd
 
+# Workaround for https://github.com/yarnpkg/yarn/issues/7584
+yarn cache clean
+
 # Service UI
 pushd /opt/manageiq/manageiq-ui-service
   yarn install


### PR DESCRIPTION
Nightly builds are failing to build SUI

```
+ [21:12:44] pushd /opt/manageiq/manageiq-ui-service
/opt/manageiq/manageiq-ui-service /
+ [21:12:44] yarn install
yarn install v1.19.0
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
error Incorrect integrity when fetching from the cache
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
To workaround this issue (https://github.com/yarnpkg/yarn/issues/7584), cleaning yarn cache after OpsUI build so I don't need to hardcode to yarn 1.18.