### PR TITLE
Change how to identify running build

### DIFF
--- a/bin/shared_functions.sh
+++ b/bin/shared_functions.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
-stop_on_existing_build ()
+stop_on_existing_imagefactory_build ()
 {
   CUR_BUILD="`virsh list | sed '1,2d'`"
   if [ -n "${CUR_BUILD}" ]
   then
     echo "Current ImageFactory Build ongoing, cannot kick-off build"
+    exit 1
+  fi
+}
+
+stop_on_existing_build ()
+{
+  if [ "`pgrep -fa ${BUILD_DIR}\/.*/vmbuild.rb`" ]; then
+    echo "vmbuild.rb running from the current directory, cannot kick-off build"
     exit 1
   fi
 }


### PR DESCRIPTION
We check for running build before starting another, but...

1. This prevents running nightly from other branches, so we can't run nightly for `master` and `ivanchuk` at the same time, which we need to do. 

1. Depending on what's being processed at the time this check happens, it might kick off another nightly anyway. We check if `virsh list` returns domains to determine if another build is running, but a virsh domain doesn't exist throughout the entire build process but exists only when certain things are processed.

So... changing to check if vmbuild.rb from the same directory is already running.

example ps output:

root      27875      1  0 Oct10 ?        00:00:00 time ruby /build/manageiq-appliance-build/bin/../scripts/vmbuild.rb --type nightly --upload --reference master --copy-dir master
