### PR TITLE
Remove 'yarn cache clean' workaround

### DIFF
--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -10,9 +10,6 @@ pushd /var/www/miq/vmdb
   rake evm:compile_sti_loader
 popd
 
-# Workaround for https://github.com/yarnpkg/yarn/issues/7584
-yarn cache clean
-
 # Service UI
 pushd /opt/manageiq/manageiq-ui-service
   yarn install


### PR DESCRIPTION
yarn 1.19.1 fixed the issue that we needed this workaround for.