### PR TITLE
Use ENV variables for optional npm/yarn registry override

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,17 @@ Below are instructions on installing and configuring a virtual machine to genera
 
     * Note: root will need password-less access to the account listed above.
 
+## Optional: Using local registry for npm/yarn
+
+To use a local registry to download npm/yarn packages, set registry url using `NPM_REGISTRY_OVERRIDE`
+environment variable:
+
+`NPM_REGISTRY_OVERRIDE=https://local.repository`
+
+To clear out the registry override and set to default values at the end of install, use `NPM_REGISTRY_RESET`:
+
+`NPM_REGISTRY_RESET=true`
+
 # Usage
 
 With installs, vnc is not directly available, but can be accessed via local vncviewer

--- a/kickstarts/partials/post/npm_registry_setup.ks.erb
+++ b/kickstarts/partials/post/npm_registry_setup.ks.erb
@@ -1,0 +1,2 @@
+npm config set registry <%= ENV['NPM_REGISTRY_OVERRIDE'] %>
+npm config set strict-ssl false

--- a/kickstarts/partials/post/npm_yarn_registry_cleanup.ks.erb
+++ b/kickstarts/partials/post/npm_yarn_registry_cleanup.ks.erb
@@ -1,0 +1,14 @@
+npm config delete registry
+npm config delete strict-ssl
+yarn config delete registry
+yarn config delete strict-ssl
+
+# Delete yarn.lock files generated
+find $(gem env gemdir)/bundler -name yarn.lock -exec rm -f {} +
+find ${repos_root} -name yarn.lock -exec rm -f {} +
+
+# Put back pre-existing yarn.lock
+for lock_file in ${yarn_lock_files}
+do
+  mv ${lock_file}.orig ${lock_file}
+done

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -1,8 +1,8 @@
-<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry.ks.erb") %>
+<%= render_partial("post/npm_registry_setup") if ENV['NPM_REGISTRY_OVERRIDE'] %>
 
 npm install -g yarn
 
-<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry_yarn.ks.erb") %>
+<%= render_partial("post/yarn_registry_setup") if ENV['NPM_REGISTRY_OVERRIDE'] %>
 
 pushd /var/www/miq/vmdb
   rake update:ui
@@ -20,4 +20,4 @@ popd
 # Clean cache, will be populated again when yarn runs next time
 yarn cache clean
 
-<%= render_partial_if_exist("/build/optional_kickstart_partials/npm_registry_cleanup.ks.erb") %>
+<%= render_partial("post/npm_yarn_registry_cleanup") if ENV['NPM_REGISTRY_RESET'] == "true" %>

--- a/kickstarts/partials/post/yarn_registry_setup.ks.erb
+++ b/kickstarts/partials/post/yarn_registry_setup.ks.erb
@@ -1,0 +1,14 @@
+yarn config set registry <%= ENV['NPM_REGISTRY_OVERRIDE'] %>
+yarn config set strict-ssl false
+
+# Replace registry in yarn.lock
+yarn_lock_files=""
+for root_dir in "${repos_root} $(gem env gemdir)/bundler"
+do
+  for lock_file in `find $root_dir -name yarn.lock`
+  do
+    yarn_lock_files+="${lock_file} "
+    cp ${lock_file} ${lock_file}.orig
+    sed -i 's$https\?://registry.\(npmjs\|yarnpkg\).\(org\|com\)$<%= ENV['NPM_REGISTRY_OVERRIDE'] %>$g' ${lock_file}
+  done
+done


### PR DESCRIPTION
Overriding npm/yarn registry is currently being done by having optional kickstart files on the build machine. Changing to use environment variables so the files can be committed to this repo and maintained properly, rather than being reviewed offline... 

Took the files we're currently using to generate our nightly builds, then changed to use environment variables.

Note: As a part of build optimization work, yarn.lock handling will be modified in upcoming PR.