### PR TITLE
Use tmpfs for node_modules and yarn cache

### DIFF
--- a/kickstarts/partials/post/npm_yarn_registry_cleanup.ks.erb
+++ b/kickstarts/partials/post/npm_yarn_registry_cleanup.ks.erb
@@ -3,12 +3,9 @@ npm config delete strict-ssl
 yarn config delete registry
 yarn config delete strict-ssl
 
-# Delete yarn.lock files generated
-find $(gem env gemdir)/bundler -name yarn.lock -exec rm -f {} +
-find ${repos_root} -name yarn.lock -exec rm -f {} +
-
-# Put back pre-existing yarn.lock
-for lock_file in ${yarn_lock_files}
+# Replace registry in yarn.lock
+default_yarn_registry=`yarn config get registry`
+for repo in ${ui_plugin_repos} ${sui_root}
 do
-  mv ${lock_file}.orig ${lock_file}
+  sed -i "s#<%= ENV['NPM_REGISTRY_OVERRIDE'] %>#${default_yarn_registry}#g" ${repo}/yarn.lock
 done

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -2,6 +2,10 @@
 
 npm install -g yarn
 
+yarn_cache_dir=`yarn cache dir`
+mkdir -p ${yarn_cache_dir}
+mount -t tmpfs tmpfs ${yarn_cache_dir}
+
 pushd /var/www/miq/vmdb
   ui_plugin_repos=`rake update:print_engines | grep path: | cut -d: -f2`
 popd
@@ -36,6 +40,6 @@ pushd /opt/manageiq/manageiq-ui-service
 popd
 
 # Clean cache, will be populated again when yarn runs next time
-yarn cache clean
+umount ${yarn_cache_dir}
 
 <%= render_partial("post/npm_yarn_registry_cleanup") if ENV['NPM_REGISTRY_RESET'] == "true" %>

--- a/kickstarts/partials/post/ui_compile.ks.erb
+++ b/kickstarts/partials/post/ui_compile.ks.erb
@@ -2,19 +2,37 @@
 
 npm install -g yarn
 
+pushd /var/www/miq/vmdb
+  ui_plugin_repos=`rake update:print_engines | grep path: | cut -d: -f2`
+popd
+
 <%= render_partial("post/yarn_registry_setup") if ENV['NPM_REGISTRY_OVERRIDE'] %>
 
 pushd /var/www/miq/vmdb
+  for repo in ${ui_plugin_repos}
+  do
+    mkdir -p $repo/node_modules
+    mount -t tmpfs tmpfs $repo/node_modules
+  done
+
   rake update:ui
   RAILS_ENV=production rake evm:compile_assets
   rake evm:compile_sti_loader
+
+  for repo in ${ui_plugin_repos}; do umount $repo/node_modules; done
 popd
 
 # Service UI
 pushd /opt/manageiq/manageiq-ui-service
+  sui_node_modules=${sui_root}/node_modules
+  mkdir -p ${sui_node_modules}
+  mount -t tmpfs tmpfs ${sui_node_modules}
+
   yarn install
   yarn run available-languages
   yarn run build
+
+  umount ${sui_node_modules}
 popd
 
 # Clean cache, will be populated again when yarn runs next time

--- a/kickstarts/partials/post/yarn_registry_setup.ks.erb
+++ b/kickstarts/partials/post/yarn_registry_setup.ks.erb
@@ -1,14 +1,11 @@
 yarn config set registry <%= ENV['NPM_REGISTRY_OVERRIDE'] %>
 yarn config set strict-ssl false
 
-# Replace registry in yarn.lock
-yarn_lock_files=""
-for root_dir in "${repos_root} $(gem env gemdir)/bundler"
+# Replace registry in existing yarn.lock
+for repo in ${ui_plugin_repos} ${sui_root}
 do
-  for lock_file in `find $root_dir -name yarn.lock`
-  do
-    yarn_lock_files+="${lock_file} "
-    cp ${lock_file} ${lock_file}.orig
-    sed -i 's$https\?://registry.\(npmjs\|yarnpkg\).\(org\|com\)$<%= ENV['NPM_REGISTRY_OVERRIDE'] %>$g' ${lock_file}
-  done
+  lock_file="${repo}/yarn.lock"
+  if [ -f "${lock_file}" ]; then
+    sed -i 's#https\?://registry.\(npmjs\|yarnpkg\).\(org\|com\)#<%= ENV['NPM_REGISTRY_OVERRIDE'] %>#g' ${lock_file}
+  fi
 done


### PR DESCRIPTION
To reduce appliance build time and final image size, changed to use tmpfs for node_modules and yarn cache.

The build time for %post section was reduced from 50min~1 hour to 40min or so. The compressed image size for vSphere went down from 2.3GB to 1.9GB.

Also since node_modules will no longer be on the appliance, yarn.lock will be left on the machine even when NPM_REGISTRY_RESET is used (but lock file will point to the yarn default registry).

Thanks for the idea @himdel 

cc @martinpovolny @bdunne @Fryguy 