### PR TITLE
Clean up extra space used by gems and bundler

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -18,3 +18,28 @@ popd
 # Install mime-types outside of bundle, needed by 'rest-client' gem when run under irb/automate
 # Run this command after 'bundle clean' so it won't be removed by 'bundle clean'
 gem install mime-types -v 2.6.1
+
+## Gem clean up
+# Unnecessary gem cache, will be rebuilt as needed
+rm -rf $(gem env gemdir)/cache/*
+
+# Vendored libgit2 shouldn't be needed once the gem is compiled
+rm -rf $(gem env gemdir)/bundler/gems/rugged-*/vendor
+
+# *.o files shouldn't be needed once gems are compiled
+find $(gem env gemdir)/gems/**/ -name *.o -delete
+find $(gem env gemdir)/bundler/gems/**/ -name *.o -delete
+
+# Remove tests that are shipped with gems
+find $(gem env gemdir)/gems/**/ -maxdepth 2 -name spec -type d -exec rm -rf {} +
+find $(gem env gemdir)/gems/**/ -maxdepth 2 -name test -type d -exec rm -rf {} +
+find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name spec -type d -exec rm -rf {} +
+find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name test -type d -exec rm -rf {} +
+rm -f $(gem env gemdir)/gems/manageiq-smartstate-*/lib/metadata/linux/test/Packages
+
+# Git directories are not needed, a new gem directory is created on update
+find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name .git -type d -exec rm -rf {} +
+
+# Remove gem docs directories
+find $(gem env gemdir)/gems/**/ -maxdepth 2 -name docs -type d -exec rm -rf {} +
+find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name docs -type d -exec rm -rf {} +

--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -6,6 +6,9 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
+mkdir -p $(gem env gemdir)/cache
+mount -t tmpfs tmpfs $(gem env gemdir)/cache
+
 gem install bundler -v ">=1.8.4"
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
@@ -20,9 +23,6 @@ popd
 gem install mime-types -v 2.6.1
 
 ## Gem clean up
-# Unnecessary gem cache, will be rebuilt as needed
-rm -rf $(gem env gemdir)/cache/*
-
 # Vendored libgit2 shouldn't be needed once the gem is compiled
 rm -rf $(gem env gemdir)/bundler/gems/rugged-*/vendor
 
@@ -43,3 +43,6 @@ find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name .git -type d -exec rm 
 # Remove gem docs directories
 find $(gem env gemdir)/gems/**/ -maxdepth 2 -name docs -type d -exec rm -rf {} +
 find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name docs -type d -exec rm -rf {} +
+
+# Free up tmpfs memory used for gem cache
+umount $(gem env gemdir)/cache


### PR DESCRIPTION
```
BEFORE ANYTHING...

[root@dhcp-8-99-141 ~]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
devtmpfs                                2.9G     0  2.9G   0% /dev
tmpfs                                   2.9G   52K  2.9G   1% /dev/shm
tmpfs                                   2.9G  904K  2.9G   1% /run
tmpfs                                   2.9G     0  2.9G   0% /sys/fs/cgroup
/dev/mapper/vg_system-lv_os              11G  3.6G  7.0G  34% /
/dev/sda1                              1014M  153M  862M  15% /boot
/dev/mapper/vg_system-lv_home          1014M   33M  982M   4% /home
/dev/mapper/vg_system-lv_tmp           1014M   33M  982M   4% /tmp
/dev/mapper/vg_system-lv_var             12G  926M   12G   8% /var
/dev/mapper/vg_system-lv_var_log         11G   55M   11G   1% /var/log
/dev/mapper/vg_data-lv_pg                13G  125M   13G   1% /var/lib/pgsql
/dev/sda3                                10G   33M   10G   1% /var/www/miq_tmp
/dev/mapper/vg_system-lv_var_log_audit  509M   27M  483M   6% /var/log/audit
tmpfs                                   581M     0  581M   0% /run/user/0


rm -rf /usr/local/lib/ruby/gems/2.5.0/cache/*

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  3.5G  7.1G  34% /


rm -rf /usr/local/lib/ruby/gems/2.5.0/bundler/gems/rugged-4b3d493ab014/vendor

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  3.5G  7.1G  33% /


find /usr/local/lib/ruby/gems/2.5.0/gems/**/ -name *.o -delete

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  3.3G  7.3G  32% /


find /usr/local/lib/ruby/gems/2.5.0/gems/**/ -maxdepth 2 -name spec -type d -exec rm -rf {} +

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  3.3G  7.3G  31% /


find /usr/local/lib/ruby/gems/2.5.0/bundler/gems/**/ -maxdepth 2 -name spec -type d -exec rm -rf {} +

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  3.0G  7.5G  29% /


rm -f /usr/local/lib/ruby/gems/2.5.0/gems/manageiq-smartstate-0.3.1/lib/metadata/linux/test/Packages
find /usr/local/lib/ruby/gems/2.5.0/bundler/gems/**/ -maxdepth 2 -name .git -type d -exec rm -rf {} +

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  2.7G  7.9G  26% /


rm -f /usr/local/lib/ruby/gems/2.5.0/bundler/gems/manageiq-v2v-79944a85e843/docs/images/quick_demo.gif

[root@dhcp-8-99-141 vmdb]# df -h
Filesystem                              Size  Used Avail Use% Mounted on
/dev/mapper/vg_system-lv_os              11G  2.7G  7.9G  26% /
```