### PR TITLE
Cleanup package installation

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -30,7 +30,7 @@ device mptspi
 
 reboot
 
-%packages
+%packages --excludedocs
 @base --nodefaults
 @development tools
 
@@ -49,6 +49,9 @@ set -x
 
 # Show timestamps on log entries for build performance tuning.
 PS4="+ [\t] "
+
+# Don't install doc
+yum-config-manager --setopt=tsflags=nodocs --save > /dev/null
 
 # Mount tmpfs on /tmp. This will remove about 200MiB of bower and bundler
 # intermediate files from the image. And do the same for /var/cache which saves
@@ -134,6 +137,9 @@ drivers="mptbase mptscsih mptspi"
 
 # make sure there is a new line at the end of sshd_config
 echo "" >> /etc/ssh/sshd_config
+
+# Remove packages not needed
+yum -C -y --noplugins remove linux-firmware doxygen
 
 # Clean the logs
 rm -vf "$vmdb_root"/log/*.log

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -14,4 +14,3 @@ repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum
 # Please also add to "post install repos" post/repos partial
 repo --name=ansible-runner --baseurl=https://releases.ansible.com/ansible-runner/rpm/epel-7-x86_64/
 repo --name=manageiq-ManageIQ-Master --baseurl=https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-7-x86_64/
-repo --name=postmodern-ruby-install --baseurl=https://copr-be.cloud.fedoraproject.org/results/postmodern/ruby-install/fedora-25-$basearch/

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -27,7 +27,6 @@ cifs-utils
 cmake                            # For rugged gem
 cockpit
 cronie
-docker                           # For embedded ansible support
 http-parser                      # libhttp_parser.so.2 needed by nodejs
 libcurl-devel                    # For curb gem
 libssh2-devel                    # For rugged SSH support


### PR DESCRIPTION
- No need to install documentation
- Remove packages installed by default but not needed (`linux-firmware` and `doxygen`)
- Remove `docker` as it's no longer needed
- Remove unused postmodern/ruby-install repo (ruby-install comes from ManageIQ-Master)