### PR TITLE
Build container images in nightly/release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ Below are instructions on configuring a dedicated build machine to generate appl
     virt-viewer     = Graphical console
     ```
 
+## Setup docker for container build
+
+  * Install docker and start service
+    ```
+    yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install docker-ce --nobest
+    systemctl enable --now docker
+    ```
+
+  * Login to a registry (for pushing image)
+    ```
+    docker login --username <user> <server> (e.g. docker.io)
+    ```
+
 ## Configure virtualization hardware
 
   * Enable virtualization

--- a/bin/container-build.sh
+++ b/bin/container-build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+if [[ $# != 1 ]]; then
+  echo "Wrong number of arguments: $#. Usage example: container-build.sh <branch or tag>"
+  exit 1
+fi
+
+BRANCH=${1%%-*}
+PODS_SOURCE_DIR="/build/manageiq-pods-${BRANCH}"
+MANAGEIQ_SOURCE_DIR="/build/manageiq-${BRANCH}"
+
+if [ "${1}" = "master" ]; then
+  tag="latest"
+elif [ "${1}" != "${BRANCH}" ]; then # tag build
+  tag="${1}"
+else # branch build
+  tag="latest-${BRANCH}"
+fi
+
+rm -rf ${PODS_SOURCE_DIR}
+git clone -b ${1} https://github.com/ManageIQ/manageiq-pods ${PODS_SOURCE_DIR}
+
+pushd ${PODS_SOURCE_DIR}
+  env MIQ_REF=${1} SUI_REF=${1} APPLIANCE_REF=${1} bin/build -n -p -d images -r manageiq -t ${tag}
+popd
+
+rm -rf ${MANAGEIQ_SOURCE_DIR}
+git clone -b ${1} --depth 1 https://github.com/ManageIQ/manageiq ${MANAGEIQ_SOURCE_DIR}
+
+pushd ${MANAGEIQ_SOURCE_DIR}
+  docker build --no-cache -t manageiq/manageiq:${tag} --build-arg IMAGE_REF=${tag} .
+  docker push manageiq/manageiq:${tag}
+popd

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -18,6 +18,7 @@ BRANCH=master
 DATE_STAMP=`date +"%Y%m%d_%T"`
 LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}.log"
 DOCS_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_docs.log"
+CONTAINER_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_container.log"
 BUILD_OPTIONS="--type nightly --upload --reference ${BRANCH} --copy-dir ${BRANCH}"
 
 if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]
@@ -32,9 +33,11 @@ then
 
   time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
   time ruby ${BUILD_DIR}/scripts/docbuild.rb 2>&1 | tee ${DOCS_LOG_FILE}
+  time bin/container-build.sh ${BRANCH} 2>&1 | tee ${CONTAINER_LOG_FILE}
 else
   nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
   nohup time ruby ${BUILD_DIR}/scripts/docbuild.rb >${DOCS_LOG_FILE} 2>&1 &
+  nohup time bin/container-build.sh ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 &
 
   echo "Nightly Build kicked off, Log @ ${LOG_FILE} ..."
 fi

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -14,3 +14,7 @@ fi
 log_file="/build/logs/${1}.log"
 nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
 echo "${1} release build kicked off, see log @ $log_file ..."
+
+container_log_file="/build/logs/${1}_container.log"
+nohup time bin/container-build.sh ${1} > $container_log_file 2>&1 &
+echo "${1} release container build kicked off, see log @ $container_log_file ..."


### PR DESCRIPTION
The new script will build pod images, followed by monolithic image, and push the images.

Since builds for 2 different branches might run at the same time, sources for container images will be cloned to branch specific directories (just like manageiq-appliance-build)

`podman` comes with CentOS 8, but the version of podman on CentOS 8.0 had a few issues, so using `docker-ce` for now. Will revisit when CentOS 8.1 is released (at least 1 issue will be fixed in that version).

cc @carbonin 