### PR TITLE
CentOS 8 based appliance

### DIFF
--- a/config/base.tdl
+++ b/config/base.tdl
@@ -1,9 +1,9 @@
 <template>
-  <name>CentOS-8.1</name>
+  <name>CentOS-7.4</name>
   <os>
     <rootpw>ozrootpw</rootpw>
-    <name>CentOS-8</name>
-    <version>1</version>
+    <name>CentOS-7</name>
+    <version>4</version>
     <arch>x86_64</arch>
     <install type="iso">
       <iso>file:///build/isos/CentOS-8.1.1911-x86_64-dvd1.iso</iso>

--- a/config/base.tdl
+++ b/config/base.tdl
@@ -1,12 +1,12 @@
 <template>
-  <name>CentOS-8.0</name>
+  <name>CentOS-8.1</name>
   <os>
     <rootpw>ozrootpw</rootpw>
     <name>CentOS-8</name>
-    <version>0</version>
+    <version>1</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-8-x86_64-1905-dvd1.iso</iso>
+      <iso>file:///build/isos/CentOS-8.1.1911-x86_64-dvd1.iso</iso>
     </install>
   </os>
   <description>CentOS TDL meant to be used with custom kickstart for manageiq.</description>

--- a/config/base.tdl
+++ b/config/base.tdl
@@ -1,15 +1,15 @@
 <template>
-  <name>CentOS-7.4</name>
+  <name>CentOS-8.0</name>
   <os>
     <rootpw>ozrootpw</rootpw>
-    <name>CentOS-7</name>
-    <version>4</version>
+    <name>CentOS-8</name>
+    <version>0</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1708.iso</iso>
+      <iso>file:///build/isos/CentOS-8-x86_64-1905-dvd1.iso</iso>
     </install>
   </os>
-  <description>CentOS74 TDL meant to be used with custom kickstart for manageiq.</description>
+  <description>CentOS TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
     <size>66G</size>
   </disk>

--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -1,9 +1,9 @@
 <template>
-  <name>CentOS-8.1</name>
+  <name>CentOS-7.4</name>
   <os>
     <rootpw>ozrootpw</rootpw>
-    <name>CentOS-8</name>
-    <version>1</version>
+    <name>CentOS-7</name>
+    <version>4</version>
     <arch>x86_64</arch>
     <install type="iso">
       <iso>file:///build/isos/CentOS-8.1.1911-x86_64-dvd1.iso</iso>

--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -1,12 +1,12 @@
 <template>
-  <name>CentOS-8.0</name>
+  <name>CentOS-8.1</name>
   <os>
     <rootpw>ozrootpw</rootpw>
     <name>CentOS-8</name>
-    <version>0</version>
+    <version>1</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-8-x86_64-1905-dvd1.iso</iso>
+      <iso>file:///build/isos/CentOS-8.1.1911-x86_64-dvd1.iso</iso>
     </install>
   </os>
   <description>CentOS TDL meant to be used with custom kickstart for manageiq.</description>

--- a/config/base_azure.tdl
+++ b/config/base_azure.tdl
@@ -1,15 +1,15 @@
 <template>
-  <name>CentOS-7.4</name>
+  <name>CentOS-8.0</name>
   <os>
     <rootpw>ozrootpw</rootpw>
-    <name>CentOS-7</name>
-    <version>4</version>
+    <name>CentOS-8</name>
+    <version>0</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-7-x86_64-DVD-1708.iso</iso>
+      <iso>file:///build/isos/CentOS-8-x86_64-1905-dvd1.iso</iso>
     </install>
   </os>
-  <description>CentOS74 TDL meant to be used with custom kickstart for manageiq.</description>
+  <description>CentOS TDL meant to be used with custom kickstart for manageiq.</description>
   <disk>
     <size>61G</size>
   </disk>

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -27,6 +27,7 @@ timezone --utc America/New_York
 <%= render_partial "main/db_fs" %>
 
 module --name mod_auth_openidc
+module --name nodejs --stream 12
 
 reboot
 

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -66,6 +66,9 @@ unset DEBUG
 # See: https://github.com/ManageIQ/manageiq/pull/6751
 export RAILS_USE_MEMORY_STORE="true"
 
+# ensure /usr/local/bin is on the path (for ruby and virtualenv)
+export PATH=$PATH:/usr/local/bin
+
 <%= render_partial "post/firewalld" %>
 
 <%= render_partial "post/source_setup" %>

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -126,7 +126,7 @@ drivers="mptspi vmw_pvscsi"
 <% else %>
 drivers="mptbase mptscsih mptspi"
 <% end %>
-/sbin/dracut --force --add-drivers "$drivers" $ramfsfile $kversion
+dracut --force --add-drivers "$drivers" $ramfsfile $kversion
 
 <%= render_partial "post/ec2" if @target == "ec2" %>
 <%= render_partial "post/azure" if @target == "azure" %>

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -26,6 +26,8 @@ timezone --utc America/New_York
 <%= render_partial "main/disk_layout" %>
 <%= render_partial "main/db_fs" %>
 
+module --name mod_auth_openidc
+
 reboot
 
 %packages --excludedocs

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -22,10 +22,6 @@ authconfig --enableshadow --passalgo=sha512
 selinux --enforcing
 timezone --utc America/New_York
 
-device mptbase
-device mptscsih
-device mptspi
-
 <%= render_partial "main/bootloader" %>
 <%= render_partial "main/disk_layout" %>
 <%= render_partial "main/db_fs" %>

--- a/kickstarts/partials/main/network.ks.erb
+++ b/kickstarts/partials/main/network.ks.erb
@@ -1,7 +1,7 @@
 <% if @target == "ec2" || @target == "azure" || @target == "openstack" %>
-network --onboot yes --device eth0 --bootproto dhcp --noipv6
+network --bootproto=dhcp --device=link --activate --onboot=on --noipv6
 <% elsif @target == "gce" %>
-network --onboot yes --device eth0 --bootproto dhcp --noipv6 --mtu=1460
+network --bootproto=dhcp --device=link --activate --onboot=on --noipv6 --mtu=1460
 <% else %>
-network --onboot yes --device eth0 --bootproto dhcp
+network --bootproto=dhcp --device=link --activate --onboot=on
 <% end %>

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -3,6 +3,7 @@ repo --name=BaseOS     --baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64
 repo --name=AppStream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
 repo --name=PowerTools --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
 repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
+repo --name=epel-playground  --baseurl=https://download.fedoraproject.org/pub/epel/playground/8/Everything/x86_64/os
 
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -3,7 +3,7 @@ repo --name=BaseOS     --baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64
 repo --name=AppStream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
 repo --name=PowerTools --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
 repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
-repo --name=epel-playground  --baseurl=https://download.fedoraproject.org/pub/epel/playground/8/Everything/x86_64/os
+repo --name=playground-mirror --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=playground-epel8&arch=x86_64
 
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -1,16 +1,13 @@
 # build time repos - these repos are used to install the initial packages
-repo --name=base    --baseurl=http://mirror.centos.org/centos/7/os/x86_64/
-repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
-repo --name=extras  --baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
-repo --name=epel    --baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
-
-# repos to install packages not found in the os
-repo --name=nodesource --baseurl=https://rpm.nodesource.com/pub_10.x/el/7/x86_64/
+repo --name=BaseOS     --baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
+repo --name=AppStream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
+repo --name=PowerTools --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
+repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
 
 <% if @target == "gce" %>
-repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-compute-el7-x86_64/
+repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable
 <% end %>
 
 # Please also add to "post install repos" post/repos partial
-repo --name=ansible-runner --baseurl=https://releases.ansible.com/ansible-runner/rpm/epel-7-x86_64/
-repo --name=manageiq-ManageIQ-Master --baseurl=https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-7-x86_64/
+repo --name=ansible-runner --baseurl=https://releases.ansible.com/ansible-runner/rpm/epel-8-x86_64/
+repo --name=manageiq-ManageIQ-Master --baseurl=https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-8-x86_64/

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -20,6 +20,7 @@ openssl-devel
 readline-devel
 zlib-devel
 
+ansible
 ansible-runner
 chrony
 cifs-utils
@@ -57,6 +58,7 @@ socat                            # for proxying remote consoles
 sqlite-devel
 telnet
 tree
+v2v-conversion-host-ansible
 vim-enhanced
 wget                             # build requires
 yum-utils

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -28,7 +28,8 @@ cockpit
 cronie
 http-parser                      # libhttp_parser.so.2 needed by nodejs
 libcurl-devel                    # For curb gem
-libssh2-devel                    # For rugged SSH support
+# WORKAROUND: installed in %post as the rpm isn't currently available for CentOS 8
+#libssh2-devel                    # For rugged SSH support
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem
 logrotate

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -1,5 +1,4 @@
-epel-release       # http://dl.fedoraproject.org/pub/epel/7/x86_64/epel-release-7-5.noarch.rpm
-nodesource-release
+epel-release
 
 createrepo
 freeipmi
@@ -41,6 +40,7 @@ nmap-ncat
 net-snmp
 net-snmp-libs
 net-snmp-utils
+network-scripts
 nfs-utils
 nodejs                           # used for asset pipeline asset compilation - From epel
 OpenIPMI
@@ -49,10 +49,9 @@ postfix                          # smtp server for sending email using localhost
 postgresql                       # appliance section
 postgresql-devel                 # for pg gem
 postgresql-server                # appliance section
-python-devel                     # for building python modules in post
+python3-devel                    # for building python modules in post
 repmgr10
 smem                             # for PSS, USS with forked processes
-screen
 socat                            # for proxying remote consoles
 sqlite-devel
 telnet
@@ -67,7 +66,6 @@ c-ares
 ipa-client
 sssd-dbus
 mod_intercept_form_submit
-mod_auth_kerb
 mod_auth_gssapi
 mod_authnz_pam
 mod_lookup_identity
@@ -110,17 +108,11 @@ hyperv-daemons
 <% when "libvirt" %>
 qemu-guest-agent
 <% when "ovirt" %>
-ovirt-guest-agent
+qemu-guest-agent
 glusterfs-fuse
 <% when "vsphere" %>
 open-vm-tools
 <% end %>
-
-# Chinese and Japanese fonts for PDF reports
-cjkuni-ukai-fonts
-cjkuni-uming-fonts
-vlgothic-fonts
-vlgothic-p-fonts
 
 # For cockpit integration
 cockpit-ws

--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -13,6 +13,11 @@ gem install bundler -v ">=1.8.4"
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 
+# WORKAROUND for libssh2-devel
+wget https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-8-x86_64/01173713-libssh2/libssh2-1.9.0-3.el8.x86_64.rpm
+wget https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-8-x86_64/01173713-libssh2/libssh2-devel-1.9.0-3.el8.x86_64.rpm
+yum -y install libssh2*.rpm
+
 pushd /var/www/miq/vmdb
   bundle install --with qpid_proton --jobs 4 --retry 3
   bundle clean --force

--- a/kickstarts/partials/post/ovirt_ansible.ks.erb
+++ b/kickstarts/partials/post/ovirt_ansible.ks.erb
@@ -1,5 +1,5 @@
 # Add oVirt repository
-yum install -y https://resources.ovirt.org/pub/yum-repo/ovirt-release43.rpm
+yum install -y https://resources.ovirt.org/pub/yum-repo/ovirt-release44-pre.rpm
 
 # For oVirt Ansible playbooks and roles
-yum install -y python-ovirt-engine-sdk4 ovirt-ansible-roles
+yum install -y python3-ovirt-engine-sdk4 ovirt-ansible-roles

--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -1,13 +1,13 @@
-yum install -y python-pip
+yum install -y python3-pip
 
 # For Nuage
-pip install vspk==5.3.2
+pip3 install vspk==5.3.2
 
 # For Lenovo
-pip install pylxca==2.1.1
+pip3 install pylxca==2.1.1
 
 # For embedded ansible
-pip install virtualenv==16.7.9
+pip3 install virtualenv
 
 mkdir -p /var/lib/manageiq/
 pushd /var/lib/manageiq
@@ -128,7 +128,7 @@ urllib3==1.24.3
 xmltodict==0.11.0
 EOF
 
-  pip install -r requirements.txt
+  pip3 install -r requirements.txt
 
   deactivate
 popd

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -5,8 +5,8 @@
 yum config-manager --set-enabled PowerTools
 
 pushd /etc/yum.repos.d/
-  wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-7/manageiq-ManageIQ-Master-epel-7.repo
-  wget https://releases.ansible.com/ansible-runner/ansible-runner.el7.repo
+  wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-8/manageiq-ManageIQ-Master-epel-8.repo
+  wget https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo
 popd
 
 <% if @target == "gce" %>

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -2,16 +2,18 @@
 # yum update uses these repos to update and reinstall packages.
 # Please also add to "build time repos" main/repos partial
 
+yum config-manager --set-enabled PowerTools
+
 pushd /etc/yum.repos.d/
   wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-7/manageiq-ManageIQ-Master-epel-7.repo
   wget https://releases.ansible.com/ansible-runner/ansible-runner.el7.repo
 popd
 
 <% if @target == "gce" %>
-cat > /etc/yum.repos.d/google-cloud-compute.repo <<EOF
-[google-cloud-compute]
-name=Google Cloud Compute
-baseurl=https://packages.cloud.google.com/yum/repos/google-cloud-compute-el7-x86_64
+cat > /etc/yum.repos.d/google-cloud.repo << EOF
+[google-compute-engine]
+name=Google Compute Engine
+baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1

--- a/kickstarts/partials/post/ruby_install.ks.erb
+++ b/kickstarts/partials/post/ruby_install.ks.erb
@@ -9,9 +9,6 @@ mount -t tmpfs tmpfs /usr/local/src
 # See: https://github.com/postmodern/ruby-install/issues/175
 ruby-install --system --jobs=4 ruby 2.5.5 -- --disable-install-doc --enable-shared
 
-# ensure /usr/local/bin is on the path as this is where ruby, gem, and bundle will be installed
-export PATH=$PATH:/usr/local/bin
-
 # Free up tmpfs memory.
 umount /usr/local/src
 

--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -16,5 +16,3 @@ ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target
 
 # Create the journal directory to enable persistant logging
 mkdir /var/log/journal
-
-systemctl disable NetworkManager

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -203,7 +203,7 @@ Dir.chdir(IMGFAC_DIR) do
     $log.info "Generating Image Checksums in #{destination_directory} ..."
     Dir.chdir(destination_directory) do
       $log.info `/usr/bin/sha256sum * > SHA256SUM`
-      $log.info `/usr/bin/gpg --batch --no-tty --passphrase-file #{passphrase_file} -b SHA256SUM`
+      $log.info `/usr/bin/gpg --batch --no-tty --passphrase-file #{passphrase_file} --pinentry-mode loopback -b SHA256SUM`
       FileUtils.cp(public_key_file, destination_directory)
     end
   end


### PR DESCRIPTION
Various changes to update our appliances to be CentOS 8 based. A few things to note...
- Not all ovirt-ansible-* packages are available for CentOS 8 and this causes none of the ovirt-ansible-* packages to be installed (due to missing dependency).
- Updated to nodejs 12 as that's the latest LTS release and is available in AppStream cc @himdel
- Due to CentOS 8 not having libssh2-devel (which is needed for rugged gem ssh support), RPMs were built in copr and are installed in %post section. Trying to install in %package fails due to conflicts.

Follow up in separate PRs:
- Change to use ruby from AppStream, rather than using ruby-install. Some extra change will be needed to make this work.
- We should probably update ruby version.

 @jrafanie I'll ping you on those 2 items above.

- Change OS install method/location. We currently use iso stored locally. The build extracts iso contents, modify and re-generate iso to be used during installation. This happens per appliance and it's time consuming. With CentOS 8 iso being 7 GB (CentOS 7 iso is 4.3 GB), this takes about 10 minutes now. I'm trying out different settings to see what works best (speed and reliability).

Other follow up items:
- Patch oz rpm that's in ManageIQ-Build copr repo. Without patch, it still works, but intermediate image files are not sparse copied, causing copy process to take significantly longer (5-7 min vs 20+ min). I've patched oz on our build machine for now.
- Look into oz not handling CentOS 8 config setting. Using CentOS 7 setting works, but it's confusing to see 7 in config/base.tdl when we're actually using 8.

Marking as WIP to do a few more test runs, but ready for review.
