### PR TITLE
Use virtualenv 16.7.9

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -7,7 +7,7 @@ pip install vspk==5.3.2
 pip install pylxca==2.1.1
 
 # For embedded ansible
-pip install virtualenv
+pip install virtualenv==16.7.9
 
 mkdir -p /var/lib/manageiq/
 pushd /var/lib/manageiq


### PR DESCRIPTION
Virtualenv 20.0.0+ (released Feb 10) is causing error setting up virtualenv on our appliances (probably because of python 2.7...)

```
+ [21:41:14] virtualenv venv
Traceback (most recent call last):
  File "/usr/bin/virtualenv", line 7, in <module>
    from virtualenv.__main__ import run_with_catch
  File "/usr/lib/python2.7/site-packages/virtualenv/__init__.py", line 3, in <module>
    from .run import cli_run
  File "/usr/lib/python2.7/site-packages/virtualenv/run/__init__.py", line 9, in <module>
    from .plugin.activators import ActivationSelector
  File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/activators.py", line 6, in <module>
    from .base import ComponentBuilder
  File "/usr/lib/python2.7/site-packages/virtualenv/run/plugin/base.py", line 9, in <module>
    from importlib_metadata import entry_points
  File "/usr/lib/python2.7/site-packages/importlib_metadata/__init__.py", line 9, in <module>
    import zipp
ImportError: No module named zipp
```

Using the latest < 20.0.0 version