### PR TITLE
Build v2v-conversion-host appliance 

### DIFF
--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -5,14 +5,14 @@ require_relative 'target'
 module Build
   class Cli
     attr_reader :options
-    ALLOWED_TYPES = %w(nightly release test)
-    DEFAULT_TYPE  = "nightly"
-    DEFAULT_REF   = "master"
-    MANAGEIQ_URL  = "https://github.com/ManageIQ/manageiq.git"
-    APPLIANCE_URL = "https://github.com/ManageIQ/manageiq-appliance.git"
-    BUILD_URL     = "https://github.com/ManageIQ/manageiq-appliance-build.git"
-    SUI_URL       = "https://github.com/ManageIQ/manageiq-ui-service.git"
-    V2V_URL       = "https://raw.github.com/ManageIQ/manageiq-v2v-conversion_host-build"
+    ALLOWED_TYPES           = %w(nightly release test)
+    DEFAULT_TYPE            = "nightly"
+    DEFAULT_REF             = "master"
+    MANAGEIQ_URL            = "https://github.com/ManageIQ/manageiq.git"
+    APPLIANCE_URL           = "https://github.com/ManageIQ/manageiq-appliance.git"
+    BUILD_URL               = "https://github.com/ManageIQ/manageiq-appliance-build.git"
+    SUI_URL                 = "https://github.com/ManageIQ/manageiq-ui-service.git"
+    V2V_CONV_HOST_KICKSTART = "https://raw.github.com/ManageIQ/manageiq-v2v-conversion_host-build"
 
     def parse(args = ARGV)
       git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"
@@ -26,27 +26,27 @@ module Build
       sui_desc       = "Repo URL containing the ManageIQ service UI code"
       upload_desc    = "Upload appliance builds to the website"
       only_desc      = "Build only specific image types.  Example: --only ovirt openstack.  Defaults to all images."
-      v2v_desc       = "Repo URL containing the v2v conversion host appliance kickstart file"
+      v2v_desc       = "Repo containing the v2v conversion host appliance kickstart raw file"
 
       @options = Optimist.options(args) do
         banner "Usage: build.rb [options]"
-        opt :appliance_ref, git_ref_desc,   :type => :string,  :short => "a", :default => DEFAULT_REF
-        opt :appliance_url, appliance_desc, :type => :string,  :short => "A", :default => APPLIANCE_URL
-        opt :build_ref,     git_ref_desc,   :type => :string,  :short => "b", :default => DEFAULT_REF
-        opt :build_url,     build_desc,     :type => :string,  :short => "B", :default => BUILD_URL
-        opt :reference,     git_ref_desc,   :type => :string,  :short => "r", :default => nil
-        opt :copy_dir,      dir_desc,       :type => :string,  :short => "d", :default => DEFAULT_REF
-        opt :fileshare,     share_desc,     :type => :boolean, :short => "f", :default => true
-        opt :local,         local_desc,     :type => :boolean, :short => "l", :default => false
-        opt :manageiq_ref,  git_ref_desc,   :type => :string,  :short => "m", :default => DEFAULT_REF
-        opt :manageiq_url,  manageiq_desc,  :type => :string,  :short => "M", :default => MANAGEIQ_URL
-        opt :only,          only_desc,      :type => :strings, :short => "o", :default => Target.default_types
-        opt :sui_ref,       git_ref_desc,   :type => :string,  :short => "s", :default => DEFAULT_REF
-        opt :sui_url,       sui_desc,       :type => :string,  :short => "S", :default => SUI_URL
-        opt :type,          type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
-        opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
-        opt :v2v_ref,       git_ref_desc,   :type => :string,  :short => "v", :default => DEFAULT_REF
-        opt :v2v_url,       v2v_desc,       :type => :string,  :short => "V", :default => V2V_URL
+        opt :appliance_ref,           git_ref_desc,   :type => :string,  :short => "a", :default => DEFAULT_REF
+        opt :appliance_url,           appliance_desc, :type => :string,  :short => "A", :default => APPLIANCE_URL
+        opt :build_ref,               git_ref_desc,   :type => :string,  :short => "b", :default => DEFAULT_REF
+        opt :build_url,               build_desc,     :type => :string,  :short => "B", :default => BUILD_URL
+        opt :reference,               git_ref_desc,   :type => :string,  :short => "r", :default => nil
+        opt :copy_dir,                dir_desc,       :type => :string,  :short => "d", :default => DEFAULT_REF
+        opt :fileshare,               share_desc,     :type => :boolean, :short => "f", :default => true
+        opt :local,                   local_desc,     :type => :boolean, :short => "l", :default => false
+        opt :manageiq_ref,            git_ref_desc,   :type => :string,  :short => "m", :default => DEFAULT_REF
+        opt :manageiq_url,            manageiq_desc,  :type => :string,  :short => "M", :default => MANAGEIQ_URL
+        opt :only,                    only_desc,      :type => :strings, :short => "o", :default => Target.default_types
+        opt :sui_ref,                 git_ref_desc,   :type => :string,  :short => "s", :default => DEFAULT_REF
+        opt :sui_url,                 sui_desc,       :type => :string,  :short => "S", :default => SUI_URL
+        opt :type,                    type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
+        opt :upload,                  upload_desc,    :type => :boolean, :short => "u", :default => false
+        opt :v2v_conv_host_ref,       git_ref_desc,   :type => :string,  :short => "v", :default => DEFAULT_REF
+        opt :v2v_conv_host_kickstart, v2v_desc,       :type => :string,  :short => "V", :default => V2V_CONV_HOST_KICKSTART
       end
 
       options[:type] &&= options[:type].strip
@@ -56,7 +56,7 @@ module Build
       end
 
       # --reference overrides all other reference arguments
-      [:manageiq_ref, :appliance_ref, :build_ref, :sui_ref, :v2v_ref].each do |ref|
+      [:manageiq_ref, :appliance_ref, :build_ref, :sui_ref, :v2v_conv_host_ref].each do |ref|
         options[ref] = (options[:reference] || options[ref]).to_s.strip
       end
       Optimist.die(:manageiq_ref, git_ref_desc) if options[:manageiq_ref].to_s.empty?

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -12,6 +12,7 @@ module Build
     APPLIANCE_URL = "https://github.com/ManageIQ/manageiq-appliance.git"
     BUILD_URL     = "https://github.com/ManageIQ/manageiq-appliance-build.git"
     SUI_URL       = "https://github.com/ManageIQ/manageiq-ui-service.git"
+    V2V_URL       = "https://raw.github.com/ManageIQ/manageiq-v2v-conversion_host-build"
 
     def parse(args = ARGV)
       git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"
@@ -25,6 +26,7 @@ module Build
       sui_desc       = "Repo URL containing the ManageIQ service UI code"
       upload_desc    = "Upload appliance builds to the website"
       only_desc      = "Build only specific image types.  Example: --only ovirt openstack.  Defaults to all images."
+      v2v_desc       = "Repo URL containing the v2v conversion host appliance kickstart file"
 
       @options = Optimist.options(args) do
         banner "Usage: build.rb [options]"
@@ -43,6 +45,8 @@ module Build
         opt :sui_url,       sui_desc,       :type => :string,  :short => "S", :default => SUI_URL
         opt :type,          type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
         opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
+        opt :v2v_ref,       git_ref_desc,   :type => :string,  :short => "v", :default => DEFAULT_REF
+        opt :v2v_url,       v2v_desc,       :type => :string,  :short => "V", :default => V2V_URL
       end
 
       options[:type] &&= options[:type].strip
@@ -52,7 +56,7 @@ module Build
       end
 
       # --reference overrides all other reference arguments
-      [:manageiq_ref, :appliance_ref, :build_ref, :sui_ref].each do |ref|
+      [:manageiq_ref, :appliance_ref, :build_ref, :sui_ref, :v2v_ref].each do |ref|
         options[ref] = (options[:reference] || options[ref]).to_s.strip
       end
       Optimist.die(:manageiq_ref, git_ref_desc) if options[:manageiq_ref].to_s.empty?

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,11 +4,11 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2 v2v)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2 v2v_conv_host)
     end
 
     it "all" do
-      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2 v2v)
+      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2 v2v_conv_host)
     end
 
     it "only vsphere and ovirt" do
@@ -20,59 +20,59 @@ describe Build::Cli do
     end
 
     it "with a branch name for reference override" do
-      expect(described_class.new.parse(%w(--reference branch_name)).options[:appliance_ref]).to eq("branch_name")
-      expect(described_class.new.parse(%w(--reference branch_name)).options[:build_ref]).to     eq("branch_name")
-      expect(described_class.new.parse(%w(--reference branch_name)).options[:manageiq_ref]).to  eq("branch_name")
-      expect(described_class.new.parse(%w(--reference branch_name)).options[:sui_ref]).to       eq("branch_name")
-      expect(described_class.new.parse(%w(--reference branch_name)).options[:v2v_ref]).to       eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:appliance_ref]).to     eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:build_ref]).to         eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:manageiq_ref]).to      eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:sui_ref]).to           eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:v2v_conv_host_ref]).to eq("branch_name")
     end
 
     it "with a branch name for appliance reference" do
-      expect(described_class.new.parse(%w(-a branch_name)).options[:appliance_ref]).to eq("branch_name")
-      expect(described_class.new.parse(%w(-a branch_name)).options[:build_ref]).to     eq("master")
-      expect(described_class.new.parse(%w(-a branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-a branch_name)).options[:sui_ref]).to       eq("master")
-      expect(described_class.new.parse(%w(-a branch_name)).options[:v2v_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:appliance_ref]).to     eq("branch_name")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:build_ref]).to         eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:manageiq_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:sui_ref]).to           eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:v2v_conv_host_ref]).to eq("master")
     end
 
     it "with a branch name for build reference" do
-      expect(described_class.new.parse(%w(-b branch_name)).options[:appliance_ref]).to eq("master")
-      expect(described_class.new.parse(%w(-b branch_name)).options[:build_ref]).to     eq("branch_name")
-      expect(described_class.new.parse(%w(-b branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-b branch_name)).options[:sui_ref]).to       eq("master")
-      expect(described_class.new.parse(%w(-b branch_name)).options[:v2v_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:appliance_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:build_ref]).to         eq("branch_name")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:manageiq_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:sui_ref]).to           eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:v2v_conv_host_ref]).to eq("master")
     end
 
     it "with a branch name for manageiq reference" do
-      expect(described_class.new.parse(%w(-m branch_name)).options[:appliance_ref]).to eq("master")
-      expect(described_class.new.parse(%w(-m branch_name)).options[:build_ref]).to     eq("master")
-      expect(described_class.new.parse(%w(-m branch_name)).options[:manageiq_ref]).to  eq("branch_name")
-      expect(described_class.new.parse(%w(-m branch_name)).options[:sui_ref]).to       eq("master")
-      expect(described_class.new.parse(%w(-m branch_name)).options[:v2v_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:appliance_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:build_ref]).to         eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:manageiq_ref]).to      eq("branch_name")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:sui_ref]).to           eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:v2v_conv_host_ref]).to eq("master")
     end
 
     it "with a branch name for sui reference" do
-      expect(described_class.new.parse(%w(-s branch_name)).options[:appliance_ref]).to eq("master")
-      expect(described_class.new.parse(%w(-s branch_name)).options[:build_ref]).to     eq("master")
-      expect(described_class.new.parse(%w(-s branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-s branch_name)).options[:sui_ref]).to       eq("branch_name")
-      expect(described_class.new.parse(%w(-s branch_name)).options[:v2v_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:appliance_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:build_ref]).to         eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:manageiq_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:sui_ref]).to           eq("branch_name")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:v2v_conv_host_ref]).to eq("master")
     end
 
-    it "with a branch name for v2v reference" do
-      expect(described_class.new.parse(%w(-v branch_name)).options[:appliance_ref]).to eq("master")
-      expect(described_class.new.parse(%w(-v branch_name)).options[:build_ref]).to     eq("master")
-      expect(described_class.new.parse(%w(-v branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(-v branch_name)).options[:sui_ref]).to       eq("master")
-      expect(described_class.new.parse(%w(-v branch_name)).options[:v2v_ref]).to       eq("branch_name")
+    it "with a branch name for v2v conversion host kickstart reference" do
+      expect(described_class.new.parse(%w(-v branch_name)).options[:appliance_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:build_ref]).to         eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:manageiq_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:sui_ref]).to           eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:v2v_conv_host_ref]).to eq("branch_name")
     end
 
     it "with DEFAULT_REF for reference override" do
-      expect(described_class.new.parse(%w(--reference master -a branch_name)).options[:appliance_ref]).to eq("master")
-      expect(described_class.new.parse(%w(--reference master -b branch_name)).options[:build_ref]).to     eq("master")
-      expect(described_class.new.parse(%w(--reference master -m branch_name)).options[:manageiq_ref]).to  eq("master")
-      expect(described_class.new.parse(%w(--reference master -s branch_name)).options[:sui_ref]).to       eq("master")
-      expect(described_class.new.parse(%w(--reference master -v branch_name)).options[:v2v_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(--reference master -a branch_name)).options[:appliance_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(--reference master -b branch_name)).options[:build_ref]).to         eq("master")
+      expect(described_class.new.parse(%w(--reference master -m branch_name)).options[:manageiq_ref]).to      eq("master")
+      expect(described_class.new.parse(%w(--reference master -s branch_name)).options[:sui_ref]).to           eq("master")
+      expect(described_class.new.parse(%w(--reference master -v branch_name)).options[:v2v_conv_host_ref]).to eq("master")
     end
 
     it "release without reference" do

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -4,11 +4,11 @@ require 'cli'
 describe Build::Cli do
   context "#parse" do
     it "only (default)" do
-      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2)
+      expect(described_class.new.parse(%w()).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2 v2v)
     end
 
     it "all" do
-      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2)
+      expect(described_class.new.parse(%w(-o all)).options[:only]).to match_array %w(vsphere ovirt openstack hyperv azure vagrant libvirt gce ec2 v2v)
     end
 
     it "only vsphere and ovirt" do
@@ -24,6 +24,7 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(--reference branch_name)).options[:build_ref]).to     eq("branch_name")
       expect(described_class.new.parse(%w(--reference branch_name)).options[:manageiq_ref]).to  eq("branch_name")
       expect(described_class.new.parse(%w(--reference branch_name)).options[:sui_ref]).to       eq("branch_name")
+      expect(described_class.new.parse(%w(--reference branch_name)).options[:v2v_ref]).to       eq("branch_name")
     end
 
     it "with a branch name for appliance reference" do
@@ -31,6 +32,7 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(-a branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(-a branch_name)).options[:manageiq_ref]).to  eq("master")
       expect(described_class.new.parse(%w(-a branch_name)).options[:sui_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-a branch_name)).options[:v2v_ref]).to       eq("master")
     end
 
     it "with a branch name for build reference" do
@@ -38,6 +40,7 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(-b branch_name)).options[:build_ref]).to     eq("branch_name")
       expect(described_class.new.parse(%w(-b branch_name)).options[:manageiq_ref]).to  eq("master")
       expect(described_class.new.parse(%w(-b branch_name)).options[:sui_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-b branch_name)).options[:v2v_ref]).to       eq("master")
     end
 
     it "with a branch name for manageiq reference" do
@@ -45,6 +48,7 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(-m branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(-m branch_name)).options[:manageiq_ref]).to  eq("branch_name")
       expect(described_class.new.parse(%w(-m branch_name)).options[:sui_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-m branch_name)).options[:v2v_ref]).to       eq("master")
     end
 
     it "with a branch name for sui reference" do
@@ -52,6 +56,15 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(-s branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(-s branch_name)).options[:manageiq_ref]).to  eq("master")
       expect(described_class.new.parse(%w(-s branch_name)).options[:sui_ref]).to       eq("branch_name")
+      expect(described_class.new.parse(%w(-s branch_name)).options[:v2v_ref]).to       eq("master")
+    end
+
+    it "with a branch name for v2v reference" do
+      expect(described_class.new.parse(%w(-v branch_name)).options[:appliance_ref]).to eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:build_ref]).to     eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:manageiq_ref]).to  eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:sui_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(-v branch_name)).options[:v2v_ref]).to       eq("branch_name")
     end
 
     it "with DEFAULT_REF for reference override" do
@@ -59,6 +72,7 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(--reference master -b branch_name)).options[:build_ref]).to     eq("master")
       expect(described_class.new.parse(%w(--reference master -m branch_name)).options[:manageiq_ref]).to  eq("master")
       expect(described_class.new.parse(%w(--reference master -s branch_name)).options[:sui_ref]).to       eq("master")
+      expect(described_class.new.parse(%w(--reference master -v branch_name)).options[:v2v_ref]).to       eq("master")
     end
 
     it "release without reference" do

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -34,11 +34,11 @@ describe Build::Target do
   end
 
   it ".supported_types" do
-    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2)
+    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2 v2v)
   end
 
   it ".default_types" do
-    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2)
+    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2 v2v)
   end
 
   it "#to_s" do

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -34,11 +34,11 @@ describe Build::Target do
   end
 
   it ".supported_types" do
-    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2 v2v)
+    expect(described_class.supported_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2 v2v_conv_host)
   end
 
   it ".default_types" do
-    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2 v2v)
+    expect(described_class.default_types).to match_array %w(openstack ovirt vsphere hyperv azure vagrant libvirt gce ec2 v2v_conv_host)
   end
 
   it "#to_s" do

--- a/scripts/spec/uploader_spec.rb
+++ b/scripts/spec/uploader_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'uploader'
+
+describe Build::Uploader do
+  subject { described_class.new("directory", "type") }
+
+  it "#devel_filename" do
+    expect(subject.send(:devel_filename, "manageiq-vsphere-master-20200213-2ddd5aa7ba.ova")).to eq("manageiq-vsphere-devel.ova")
+    expect(subject.send(:devel_filename, "manageiq-gce-master-20200213-2ddd5aa7ba.tar.gz")).to eq("manageiq-gce-devel.tar.gz")
+  end
+
+  it "#nightly_filename" do
+    expect(subject.send(:nightly_filename, "manageiq-vsphere-master-202002130919-2ddd5aa7ba.ova")).to eq("manageiq-vsphere-master-20200213-2ddd5aa7ba.ova")
+    expect(subject.send(:nightly_filename, "manageiq-gce-ivanchuk-202002130919-2ddd5aa7ba.tar.gz")).to eq("manageiq-gce-ivanchuk-20200213-2ddd5aa7ba.tar.gz")
+  end
+
+  it "#release_filename" do
+    expect(subject.send(:release_filename, "manageiq-azure-ivanchuk-1-beta1-201907251305-cede8d335c.zip")).to eq("manageiq-azure-ivanchuk-1-beta1.zip")
+    expect(subject.send(:release_filename, "manageiq-gce-ivanchuk-1-201909111431-9f959bdc02.tar.gz")).to eq("manageiq-gce-ivanchuk-1.tar.gz")
+    expect(subject.send(:release_filename, "manageiq-gce-hammer-1-beta1.1-201810101501-7992680416.tar.gz")).to eq("manageiq-gce-hammer-1-beta1.1.tar.gz")
+  end
+end

--- a/scripts/spec/uploader_spec.rb
+++ b/scripts/spec/uploader_spec.rb
@@ -7,16 +7,19 @@ describe Build::Uploader do
   it "#devel_filename" do
     expect(subject.send(:devel_filename, "manageiq-vsphere-master-20200213-2ddd5aa7ba.ova")).to eq("manageiq-vsphere-devel.ova")
     expect(subject.send(:devel_filename, "manageiq-gce-master-20200213-2ddd5aa7ba.tar.gz")).to eq("manageiq-gce-devel.tar.gz")
+    expect(subject.send(:devel_filename, "v2v-conversion-host-appliance-master-20200213.qc2")).to eq("v2v-conversion-host-appliance-devel.qc2")
   end
 
   it "#nightly_filename" do
     expect(subject.send(:nightly_filename, "manageiq-vsphere-master-202002130919-2ddd5aa7ba.ova")).to eq("manageiq-vsphere-master-20200213-2ddd5aa7ba.ova")
     expect(subject.send(:nightly_filename, "manageiq-gce-ivanchuk-202002130919-2ddd5aa7ba.tar.gz")).to eq("manageiq-gce-ivanchuk-20200213-2ddd5aa7ba.tar.gz")
+    expect(subject.send(:nightly_filename, "v2v-conversion-host-appliance-master-202002130919.qc2")).to eq("v2v-conversion-host-appliance-master-20200213.qc2")
   end
 
   it "#release_filename" do
     expect(subject.send(:release_filename, "manageiq-azure-ivanchuk-1-beta1-201907251305-cede8d335c.zip")).to eq("manageiq-azure-ivanchuk-1-beta1.zip")
     expect(subject.send(:release_filename, "manageiq-gce-ivanchuk-1-201909111431-9f959bdc02.tar.gz")).to eq("manageiq-gce-ivanchuk-1.tar.gz")
     expect(subject.send(:release_filename, "manageiq-gce-hammer-1-beta1.1-201810101501-7992680416.tar.gz")).to eq("manageiq-gce-hammer-1-beta1.1.tar.gz")
+    expect(subject.send(:release_filename, "v2v-conversion-host-appliance-ivanchuk-1-202002130919.qc2")).to eq("v2v-conversion-host-appliance-ivanchuk-1.qc2")
   end
 end

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -12,6 +12,7 @@ module Build
       'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
       'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil, '66'),
       'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip', '66'),
+      'v2v'       => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '10'),
     }
 
     attr_reader :name

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -3,16 +3,16 @@ module Build
     ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension, :compression_type, :image_size)
 
     TYPES = {
-      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil, '66'),
-      'ovirt'     => ImagefactoryMetadata.new('rhevm', nil, 'qc2', 'qemu-qcow2', '66'),
-      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip', '66'),
-      'azure'     => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip', '61'),
-      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil, '66'),
-      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
-      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil, '66'),
-      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip', '66'),
-      'v2v'       => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '10'),
+      'vsphere'       => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil, '66'),
+      'ovirt'         => ImagefactoryMetadata.new('rhevm', nil, 'qc2', 'qemu-qcow2', '66'),
+      'openstack'     => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
+      'hyperv'        => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip', '66'),
+      'azure'         => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip', '61'),
+      'vagrant'       => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil, '66'),
+      'libvirt'       => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
+      'gce'           => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil, '66'),
+      'ec2'           => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip', '66'),
+      'v2v_conv_host' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '10'),
     }
 
     attr_reader :name

--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -22,10 +22,9 @@ module Build
     def run
       login
 
-      appliances = Dir.glob("#{directory}/manageiq*")
-      appliances.each do |appliance|
-        # Skip badly named appliances, missing git sha: manageiq-openstack-master-201407142000-.qc2
-        unless appliance.match?(/.+-[0-9]{12}-[0-9a-fA-F]+/)
+      Dir.glob("#{directory}/*").each do |appliance|
+        # Skip files without date
+        unless appliance.match?(/.+-[0-9]{12}/)
           puts "Skipping #{appliance}"
           next
         end
@@ -139,21 +138,18 @@ module Build
     end
 
     def devel_filename(appliance_name)
-      name = appliance_name.split("-")
-      extension = ".#{appliance_name.split(".", 2).last}"
-      (name[0..1] << "devel").join("-") + extension
+      name = appliance_name.match(/(.*-).*-[0-9]{8}(?:-\h*)?(.*)/)
+      "#{name[1]}devel#{name[2]}"
     end
 
     def nightly_filename(appliance_name)
-      name = appliance_name.split("-")
-      name[-2] = name[-2][0, 8]
-      name.join("-")
+      name = appliance_name.match(/(.*)([0-9]{12})(.*)/)
+      "#{name[1]}#{name[2][0, 8]}#{name[3]}"
     end
 
     def release_filename(appliance_name)
-      name = appliance_name.split("-")
-      ext = name[-1].sub(/\h*/, '')
-      name[0..-3].join("-") << ext
+      name = appliance_name.match(/(.*)-[0-9]{12}(?:-\h*)?(.*)/)
+      "#{name[1]}#{name[2]}"
     end
   end
 end

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -117,6 +117,11 @@ Dir.chdir(IMGFAC_DIR) do
     $log.info "              tdl_file: #{tdl_file}, ova_file: #{ova_file}."
 
     input_file  = ks_gen.gen_file_path("base-#{target}.ks")
+
+    if target.name == "v2v"
+      `curl -L #{cli_options[:v2v_url]}/#{cli_options[:v2v_ref]}/appliance/uci_image.ks -o #{input_file}`
+    end
+
     output_file = ks_gen.gen_file_path("base-#{target}-#{build_label}-#{timestamp}.ks")
 
     FileUtils.cp(input_file, output_file)
@@ -155,7 +160,11 @@ Dir.chdir(IMGFAC_DIR) do
     $log.info "Built #{target} with final UUID: #{uuid}"
 
     FileUtils.mkdir_p(destination_directory)
-    file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{manageiq_checkout.commit_sha}.#{target.file_extension}"
+    if target.name == "v2v"
+      file_name = "v2v-conversion-host-appliance-#{build_label}-#{timestamp}.#{target.file_extension}"
+    else
+      file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{manageiq_checkout.commit_sha}.#{target.file_extension}"
+    end
     destination = destination_directory.join(file_name)
 
     Dir.chdir(STORAGE_DIR) do

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -118,8 +118,8 @@ Dir.chdir(IMGFAC_DIR) do
 
     input_file  = ks_gen.gen_file_path("base-#{target}.ks")
 
-    if target.name == "v2v"
-      `curl -L #{cli_options[:v2v_url]}/#{cli_options[:v2v_ref]}/appliance/uci_image.ks -o #{input_file}`
+    if target.name == "v2v_conv_host"
+      `curl -L #{cli_options[:v2v_conv_host_kickstart]}/#{cli_options[:v2v_conv_host_ref]}/appliance/uci_image.ks -o #{input_file}`
     end
 
     output_file = ks_gen.gen_file_path("base-#{target}-#{build_label}-#{timestamp}.ks")
@@ -160,7 +160,7 @@ Dir.chdir(IMGFAC_DIR) do
     $log.info "Built #{target} with final UUID: #{uuid}"
 
     FileUtils.mkdir_p(destination_directory)
-    if target.name == "v2v"
+    if target.name == "v2v_conv_host"
       file_name = "v2v-conversion-host-appliance-#{build_label}-#{timestamp}.#{target.file_extension}"
     else
       file_name = "#{name}-#{target}-#{build_label}-#{timestamp}-#{manageiq_checkout.commit_sha}.#{target.file_extension}"


### PR DESCRIPTION
v2v-conversion-host appliance is different from the rest of appliances we build, where kickstart file comes from a different repo and the final appliance file name has different format.

For now, I've opted to handle those differences using `if target == "v2v"`. If we ever need to create another non-ManageIQ appliance, I'll look into either adding new options in Build::Target or re-organizing vmbuild.rb so target specific `if` can be removed.

Requires https://github.com/ManageIQ/manageiq-appliance-build/pull/383