### PR TITLE
Fix date parsing to account for v2v appliance

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -39,7 +39,7 @@ module Build
 
         upload_headers = headers.merge("ETag" => source_hash)
         if nightly?
-          image_date = destination_name.split("-")[-2]
+          image_date = destination_name.match(/.*([0-9]{8}).*/)[1]
           delete_at  = (DateTime.parse(image_date) + NIGHTLY_BUILD_RETENTION_TIME)
           upload_headers["X-Delete-At"] = delete_at.to_i.to_s
         end


### PR DESCRIPTION
In https://github.com/ManageIQ/manageiq-appliance-build/pull/385, I missed one place where date parsing needed to be updated. Changed to use the similar regex as generating filenames.