### PR TITLE
Increase v2_conv_host appliance to 20GB

### DIFF
--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -12,7 +12,7 @@ module Build
       'libvirt'       => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
       'gce'           => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil, '66'),
       'ec2'           => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip', '66'),
-      'v2v_conv_host' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '10'),
+      'v2v_conv_host' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '20'),
     }
 
     attr_reader :name


### PR DESCRIPTION
As per request... virt-v2v requires more space than what's currently available, so increasing disk size to 20GB.

cc @fdupont-redhat