### PR TITLE
Replace playground repo with epel

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -3,7 +3,7 @@ repo --name=BaseOS     --baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64
 repo --name=AppStream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
 repo --name=PowerTools --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
 repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
-repo --name=playground-mirror --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=playground-epel8&arch=x86_64
+repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64
 
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable


### PR DESCRIPTION
All packages can now come from epel and/or other repos already defined and no need to use playground any more.  epel is more stable than playground and preferred.