### PR TITLE
Remove libssh2 workaround

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -29,8 +29,7 @@ cockpit
 cronie
 http-parser                      # libhttp_parser.so.2 needed by nodejs
 libcurl-devel                    # For curb gem
-# WORKAROUND: installed in %post as the rpm isn't currently available for CentOS 8
-#libssh2-devel                    # For rugged SSH support
+libssh2-devel                    # For rugged SSH support
 libxml2-devel                    # For nokogiri gem
 libxslt-devel                    # For nokogiri gem
 logrotate

--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -13,11 +13,6 @@ gem install bundler -v ">=1.8.4"
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 
-# WORKAROUND for libssh2-devel
-wget https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-8-x86_64/01173713-libssh2/libssh2-1.9.0-3.el8.x86_64.rpm
-wget https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Master/epel-8-x86_64/01173713-libssh2/libssh2-devel-1.9.0-3.el8.x86_64.rpm
-yum -y install libssh2*.rpm
-
 pushd /var/www/miq/vmdb
   bundle install --with qpid_proton --jobs 4 --retry 3
   bundle clean --force


### PR DESCRIPTION
CentOS 8 repo no longer contains libssh2 rpm and installing from ManageIQ copr repo won't conflict, so removing the workaround.