### PR TITLE
Update gem clean up

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -24,7 +24,7 @@ gem install mime-types -v 2.6.1
 
 ## Gem clean up
 # Vendored libgit2 shouldn't be needed once the gem is compiled
-rm -rf $(gem env gemdir)/bundler/gems/rugged-*/vendor
+rm -rf $(gem env gemdir)/gems/rugged-*/vendor
 
 # *.o files shouldn't be needed once gems are compiled
 find $(gem env gemdir)/gems/**/ -name *.o -delete
@@ -35,7 +35,6 @@ find $(gem env gemdir)/gems/**/ -maxdepth 2 -name spec -type d -exec rm -rf {} +
 find $(gem env gemdir)/gems/**/ -maxdepth 2 -name test -type d -exec rm -rf {} +
 find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name spec -type d -exec rm -rf {} +
 find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name test -type d -exec rm -rf {} +
-rm -f $(gem env gemdir)/gems/manageiq-smartstate-*/lib/metadata/linux/test/Packages
 
 # Git directories are not needed, a new gem directory is created on update
 find $(gem env gemdir)/bundler/gems/**/ -maxdepth 2 -name .git -type d -exec rm -rf {} +


### PR DESCRIPTION
- Updated path to rugged, as it's no longer a git based gem
- manageiq-smartstate gem no longer contains "Packages" file