### PR TITLE
Bundle with 'systemd' optional group

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -14,7 +14,8 @@ gem install bundler -v ">=1.8.4"
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 
 pushd /var/www/miq/vmdb
-  bundle install --with qpid_proton --jobs 4 --retry 3
+  bundle config set --local with qpid_proton systemd
+  bundle install --jobs 4 --retry 3
   bundle clean --force
 popd
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq/pull/19874

Also changed to use `bundle config set` rather than `--with` due to deprecation warning:

[DEPRECATED] The `--with` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set with 'qpid_proton'`, and stop using this flag