### PR TITLE
Add centos 8 download doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Below are instructions on configuring a dedicated build machine to generate appl
   initrd http://pxeserver.example.com/sources/centos/8/initrd.img
   boot
   ```
-
+## Download CentOS 8 ISO
+  * Download latest CentOS 8 ISO from https://www.centos.org/download/
+    ```
+    curl -L http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8.1.1911-x86_64-dvd1.iso \
+      -o /build/isos/CentOS-8.1.1911-x86_64-dvd1.iso
+    ```
+    
 ## Setup docker for container build
 
   * Install docker and start service

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below are instructions on configuring a dedicated build machine to generate appl
   boot
   ```
 ## Download CentOS 8 ISO
-  * Download latest CentOS 8 ISO from https://www.centos.org/download/
+  * Download latest CentOS 8 ISO from http://isoredirect.centos.org/centos/8/isos/x86_64/
     ```
     curl -L http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8.1.1911-x86_64-dvd1.iso \
       -o /build/isos/CentOS-8.1.1911-x86_64-dvd1.iso


### PR DESCRIPTION
Add documentation step to download and place centos 8 iso.
This includes an example link that is current but that link will change with each release of centos 8. I am not sure if there is a way to link to the latest version directly.

Issue: https://github.com/ManageIQ/manageiq-appliance-build/issues/398