### PR TITLE
Don't error when upload is called without upload.yml

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -8,9 +8,14 @@ module Build
     attr_reader :container, :directory, :type
 
     NIGHTLY_BUILD_RETENTION_TIME = 8.weeks
+    CONFIG_FILE = Pathname.new(__dir__).join("../config/upload.yml")
 
     def self.upload(directory, type)
-      new(directory, type).run
+      if File.exist?(CONFIG_FILE)
+        new(directory, type).run
+      else
+        puts "#{CONFIG_FILE} doesn't exist, not uploading images"
+      end
     end
 
     def initialize(directory, type)
@@ -84,7 +89,7 @@ module Build
     end
 
     def config
-      @config ||= YAML.load_file("#{__dir__}/../config/upload.yml")
+      @config ||= YAML.load_file(CONFIG_FILE)
     end
 
     def login


### PR DESCRIPTION
```
/usr/share/ruby/psych.rb:497:in `initialize': No such file or directory @ rb_sysopen - /build/manageiq-appliance-build/scripts/../config/upload.yml (Errno::ENOENT)
	from /usr/share/ruby/psych.rb:497:in `open'
	from /usr/share/ruby/psych.rb:497:in `load_file'
	from /build/manageiq-appliance-build/scripts/uploader.rb:87:in `config'
	from /build/manageiq-appliance-build/scripts/uploader.rb:97:in `login'
	from /build/manageiq-appliance-build/scripts/uploader.rb:23:in `run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:13:in `upload'
	from /build/manageiq-appliance-build/bin/../scripts/vmbuild.rb:248:in `<main>'
```