### PR TITLE
Control qpid-proton rpm version by installing from ManageIQ copr repo

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -3,7 +3,7 @@ repo --name=BaseOS     --baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64
 repo --name=AppStream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
 repo --name=PowerTools --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
 repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
-repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64
+repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
 
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -3,6 +3,7 @@
 # Please also add to "build time repos" main/repos partial
 
 yum config-manager --set-enabled PowerTools
+yum config-manager --setopt=epel.exclude=*qpid-proton* --save
 
 pushd /etc/yum.repos.d/
   wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Master/repo/epel-8/manageiq-ManageIQ-Master-epel-8.repo


### PR DESCRIPTION
Disallow installing qpid-proton from epel repo (so it will come from ManageIQ copr repo), to ensure the version matches with the gem version.

Related to: https://github.com/ManageIQ/manageiq/issues/19942 and https://github.com/ManageIQ/manageiq/pull/20016

Building 0.30.0 rpm in ManageIQ-Master and ManageIQ-Jansa copr repo now.  Until https://github.com/ManageIQ/manageiq/pull/20016 is merged, bundle will fail on master/jansa appliances with or without this PR.