### PR TITLE
[IVANCHUK] Control qpid-proton rpm version by installing from ManageIQ copr repo 

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -2,7 +2,7 @@
 repo --name=base    --baseurl=http://mirror.centos.org/centos/7/os/x86_64/
 repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
 repo --name=extras  --baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
-repo --name=epel    --baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/
+repo --name=epel    --baseurl=http://dl.fedoraproject.org/pub/epel/7/x86_64/ --excludepkgs=*qpid-proton*
 
 # repos to install packages not found in the os
 repo --name=nodesource --baseurl=https://rpm.nodesource.com/pub_10.x/el/7/x86_64/

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -2,6 +2,7 @@
 # yum update uses these repos to update and reinstall packages.
 # Please also add to "build time repos" main/repos partial
 
+yum-config-manager --setopt=epel.exclude=*qpid-proton* --save
 pushd /etc/yum.repos.d/
   wget https://copr.fedorainfracloud.org/coprs/manageiq/ManageIQ-Ivanchuk/repo/epel-7/manageiq-ManageIQ-Ivanchuk-epel-7.repo
   wget https://releases.ansible.com/ansible-runner/ansible-runner.el7.repo


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-appliance-build/pull/409 as yum command is slightly different.

Since qpid_proton gem 0.26.0 was being used with 0.29.0 rpm without any problem, kicked off 0.29.0 rpm build in ManageIQ-Ivanchuk copr repo.

EPEL was updated to 0.30.0 rpm 2-3 weeks ago, and `bundle install` is failing since.