### PR TITLE
Upload to multiple destinations

### DIFF
--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -164,7 +164,7 @@ module Build
           client.put_object(put_options.merge(:body => content))
         end
 
-        status = response.etag == options[:source_hash] ? "complete" : "checksum-mismatch"
+        status = response.etag.tr("\\\"", "") == options[:source_hash] ? "complete" : "checksum-mismatch"
         puts "Uploading #{appliance} to DigitalOcean as #{destination}...#{status}"
       end
 

--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -49,15 +49,8 @@ module Build
 
         if nightly?
           devel = devel_filename(destination_name)
-          puts "Copying   #{appliance} to #{devel}..."
 
-          RestClient::Request.execute(
-            :method  => :copy,
-            :url     => destination_url,
-            :headers => token_headers.merge("Destination" => "/#{container}/#{devel}")
-          )
-
-          puts "Copying   #{appliance} to #{devel}...complete"
+          rackspace_client.copy(destination_name, devel)
         end
       end
     end
@@ -109,6 +102,19 @@ module Build
         )
 
         puts "Uploading #{appliance} to Rackspace as #{destination}...complete: #{destination_url}"
+      end
+
+      def copy(source, destination)
+        appliance = File.basename(source)
+        puts "Copying   #{appliance} to #{destination} on Rackspace..."
+
+        RestClient::Request.execute(
+          :method  => :copy,
+          :url     => url(source),
+          :headers => token_headers.merge("Destination" => "/#{container}/#{destination}")
+        )
+
+        puts "Copying   #{appliance} to #{destination} on Rackspace...complete"
       end
 
       private

--- a/scripts/uploader.rb
+++ b/scripts/uploader.rb
@@ -150,6 +150,9 @@ module Build
         @endpoint   = config[:endpoint]
       end
 
+      def login
+      end
+
       def upload(source, destination, options)
         appliance = File.basename(source)
         puts "Uploading #{appliance} to DigitalOcean as #{destination}..."


### PR DESCRIPTION
In order to enable migrating to a new CDN
- Refactored the code to split the Rackspace specifics out of the common methods
- Added a DigitalOcean uploader

Once this is running and new builds are being uploaded to both destinations, I will script back-filling all of the existing images.  When the switch to DigitalOcean Spaces is complete I will remove the Rackspace calls.