### PR TITLE
Add building RPMs before starting appliance build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 config/generated/base*.tdl
 kickstarts/generated/*.ks
 scripts/Gemfile.dev.rb
+OPTIONS

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -19,6 +19,7 @@ DATE_STAMP=`date +"%Y%m%d_%T"`
 LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}.log"
 DOCS_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_docs.log"
 CONTAINER_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_container.log"
+RPM_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_rpm.log"
 BUILD_OPTIONS="--type nightly --upload --reference ${BRANCH} --copy-dir ${BRANCH}"
 
 if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]
@@ -29,15 +30,20 @@ fi
 
 if [ "${1}" = "--fg" ]
 then
-  echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
-
-  time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
   time ruby ${BUILD_DIR}/scripts/docbuild.rb 2>&1 | tee ${DOCS_LOG_FILE}
+
+  echo "Nightly RPM build kicked off, Log being saved in ${RPM_LOG_FILE} ..."
+  ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH 2>&1 |tee ${RPM_LOG_FILE}
+  [ ${PIPESTATUS[0]} -ne 0 ] && exit 1
+
+  echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
+  time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
   time ${BUILD_DIR}/bin/container-build.sh ${BRANCH} 2>&1 | tee ${CONTAINER_LOG_FILE}
 else
-  nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
   nohup time ruby ${BUILD_DIR}/scripts/docbuild.rb >${DOCS_LOG_FILE} 2>&1 &
-  nohup time ${BUILD_DIR}/bin/container-build.sh ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 &
+  ( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH > ${RPM_LOG_FILE} 2>&1 &&
+    ( nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
+      nohup time ${BUILD_DIR}/bin/container-build.sh ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 ) ) &
 
-  echo "Nightly Build kicked off, Log @ ${LOG_FILE} ..."
+  echo "Nightly Build kicked off, Logs @ ${LOG_DIR}/${BRANCH}_${DATE_STAMP}*.log..."
 fi

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -11,10 +11,12 @@ if [[ $# != 1 ]]; then
   exit 1
 fi
 
+rpm_log_file="/build/logs/${1}_rpm.log"
 log_file="/build/logs/${1}.log"
-nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
-echo "${1} release build kicked off, see log @ $log_file ..."
-
 container_log_file="/build/logs/${1}_container.log"
-nohup time ${BUILD_DIR}/bin/container-build.sh ${1} > $container_log_file 2>&1 &
-echo "${1} release container build kicked off, see log @ $container_log_file ..."
+
+( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t release -r ${1} > $rpm_log_file 2>&1;
+  nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
+  nohup time ${BUILD_DIR}/bin/container-build.sh ${1} > $container_log_file 2>&1 ) &
+
+echo "${1} release build kicked off, see logs @ /build/logs/${1}*.log ..."

--- a/bin/rpm-build.sh
+++ b/bin/rpm-build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -ex
+
+BUILD_DIR="$(dirname "$(readlink -f "$0")")/.."
+
+CONFIG_OPTION=${CONFIG_OPTION:-$BUILD_DIR/OPTIONS}
+COPR_TOKEN=${COPR_TOKEN:-~/.config/copr}
+RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build"}
+
+while getopts "t:r:h" opt; do
+  case $opt in
+    t) BUILD_TYPE=$OPTARG ;;
+    r) REF=$OPTARG ;;
+    h) echo "Usage: $0 -t BUILD_TYPE -r REF [-h]"; exit 1
+  esac
+done
+
+if [ "$BUILD_TYPE" != "nightly" ] && [ "$BUILD_TYPE" != "release" ]; then
+  echo "Build type (-t) is required, must be either 'nightly' or 'release'"
+  exit 1
+fi
+
+if [ -z "$REF" ]; then
+  echo "ref (-r) is required"
+  exit 1
+fi
+
+if [ "$REF" = "master" ]; then
+  tag="latest"
+else
+  tag="latest-${REF%%-*}"
+fi
+RPM_BUILD_IMAGE=$RPM_BUILD_IMAGE:$tag
+
+cmd="build --build-type $BUILD_TYPE --git-ref $REF"
+docker pull $RPM_BUILD_IMAGE
+docker run --rm -v $COPR_TOKEN:/root/.config/copr -v $CONFIG_OPTION:/root/OPTIONS $RPM_BUILD_IMAGE $cmd

--- a/bin/rpm-build.sh
+++ b/bin/rpm-build.sh
@@ -4,8 +4,8 @@ set -ex
 BUILD_DIR="$(dirname "$(readlink -f "$0")")/.."
 
 CONFIG_OPTION=${CONFIG_OPTION:-$BUILD_DIR/OPTIONS}
-COPR_TOKEN=${COPR_TOKEN:-~/.config/copr}
 RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build"}
+RPM_CACHE_DIR=${RPM_CACHE_DIR:-$BUILD_DIR/rpm_cache}
 
 while getopts "t:r:h" opt; do
   case $opt in
@@ -32,6 +32,6 @@ else
 fi
 RPM_BUILD_IMAGE=$RPM_BUILD_IMAGE:$tag
 
-cmd="build --build-type $BUILD_TYPE --git-ref $REF"
+cmd="build --build-type $BUILD_TYPE --git-ref $REF --update-rpm-repo"
 docker pull $RPM_BUILD_IMAGE
-docker run --rm -v $COPR_TOKEN:/root/.config/copr -v $CONFIG_OPTION:/root/OPTIONS $RPM_BUILD_IMAGE $cmd
+docker run --rm -v $CONFIG_OPTION:/root/OPTIONS -v $RPM_CACHE_DIR:/root/rpm_cache $RPM_BUILD_IMAGE $cmd


### PR DESCRIPTION
Once we go RPM based, majority of the code will come from RPMs and there is very little left outside of it. So I made appliance/container build not to start if RPM build wasn't successful. I think this is less confusing than having an appliance build with RPMs from the day before.

Copr token and options.yml need to be setup on the build machine.

TODOs (follow up PRs)
- Clean up options/code no longer used
- Add support for "local" build - with this PR, you will not be able to use non-default repo/branches for nightly/release build, unless you add manual steps to build own RPMs, then change yum repo.

Related PR: https://github.com/ManageIQ/manageiq-appliance-build/pull/415