### PR TITLE
Update to oVirt 4.4 GA

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -4,6 +4,7 @@ repo --name=AppStream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86
 repo --name=PowerTools --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
 repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
 repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
+repo --name=ovirt      --mirrorlist=https://resources.ovirt.org/pub/yum-repo/mirrorlist-ovirt-4.4-el$releasever
 
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable

--- a/kickstarts/partials/post/ovirt_ansible.ks.erb
+++ b/kickstarts/partials/post/ovirt_ansible.ks.erb
@@ -1,5 +1,5 @@
 # Add oVirt repository
-yum install -y https://resources.ovirt.org/pub/yum-repo/ovirt-release44-pre.rpm
+yum install -y https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm
 
 # For oVirt Ansible playbooks and roles
 yum install -y python3-ovirt-engine-sdk4 ovirt-ansible-roles


### PR DESCRIPTION
With the revert of IMS 1.3 changes, we need to downgrade v2v-conversion-host as well. The needed version is provided by oVirt 4.4, which went GA last week.

Related PR: https://github.com/ManageIQ/manageiq/pull/20168