### PR TITLE
Add nightly yum repo only for non-release build

### DIFF
--- a/bin/kickstart_build.rb
+++ b/bin/kickstart_build.rb
@@ -14,5 +14,6 @@ options = Build::Cli.parse.options
 
 Build::KickstartGenerator.new(
   File.expand_path("..", __dir__),
+  options[:type],
   options[:only],
   nil).run

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -8,7 +8,9 @@ repo --name=ovirt      --mirrorlist=https://resources.ovirt.org/pub/yum-repo/mir
 
 repo --name=manageiq-kasparov         --baseurl=https://rpm.manageiq.org/release/11-kasparov/el$releasever/$basearch
 repo --name=manageiq-kasparov-noarch  --baseurl=https://rpm.manageiq.org/release/11-kasparov/el$releasever/noarch
+<% if @build_type != "release" %>
 repo --name=manageiq-kasparov-nightly --baseurl=https://rpm.manageiq.org/release/11-kasparov-nightly/el$releasever/$basearch
+<% end %>
 
 <% if @target == "gce" %>
 repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -4,6 +4,9 @@
 
 dnf config-manager --set-enabled PowerTools
 dnf config-manager --setopt=epel.exclude=*qpid-proton* --save
+<% if @build_type != "release" %>
+dnf config-manager --enable manageiq-*-nightly
+<% end %>
 
 pushd /etc/yum.repos.d/
   wget https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo

--- a/scripts/kickstart_generator.rb
+++ b/scripts/kickstart_generator.rb
@@ -13,8 +13,9 @@ module Build
 
     attr_reader :targets, :puddle
 
-    def initialize(build_base, targets, puddle)
+    def initialize(build_base, build_type, targets, puddle)
       @build_base         = Pathname.new(build_base)
+      @build_type         = build_type
       @ks_gen_base        = @build_base.join(KS_GEN_DIR)
       @targets            = targets
       @puddle             = puddle # used during ERB evaluation

--- a/scripts/spec/kickstart_generator_spec.rb
+++ b/scripts/spec/kickstart_generator_spec.rb
@@ -7,7 +7,7 @@ describe Build::KickstartGenerator do
     let(:generated)  { "#{build_base}/kickstarts/generated" }
     let(:ks_text)    { File.read("#{generated}/base-target.ks") }
 
-    subject { described_class.new(build_base, ["target"], "puddle") }
+    subject { described_class.new(build_base, "release", ["target"], "puddle") }
 
     after do
       FileUtils.rm_rf(generated)

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -84,7 +84,7 @@ name            = "manageiq"
 
 targets = cli_options[:only].collect { |only| Build::Target.new(only) }
 
-ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:only], puddle)
+ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:type], cli_options[:only], puddle)
 ks_gen.run
 
 file_rdu_dir_base = FILE_SERVER_BASE.join(directory)


### PR DESCRIPTION
With this change, nightly appliance will have nightly yum repo enabled by default, allowing `yum update` to pick up the latest manageiq-* RPMs from nightly/release repos.

The release appliances will continue to only have release repo enabled by default and the users are expected to enable nightly repo to update to a nightly build.

