### PR TITLE
Move ovirt-ansible-roles to manageiq-gemset requires

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -76,8 +76,6 @@ export PATH=$PATH:/usr/local/bin
 
 <%= render_partial "post/repos" %>
 
-<%= render_partial "post/ovirt_ansible" %>
-
 <%= render_partial "post/python_modules" %>
 
 source /etc/default/evm

--- a/kickstarts/partials/post/ovirt_ansible.ks.erb
+++ b/kickstarts/partials/post/ovirt_ansible.ks.erb
@@ -1,5 +1,0 @@
-# Add oVirt repository
-dnf install -y https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm
-
-# For oVirt Ansible playbooks and roles
-dnf install -y python3-ovirt-engine-sdk4 ovirt-ansible-roles

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -8,6 +8,8 @@ dnf config-manager --setopt=epel.exclude=*qpid-proton* --save
 dnf config-manager --enable manageiq-*-nightly
 <% end %>
 
+dnf install -y https://resources.ovirt.org/pub/yum-repo/ovirt-release44.rpm
+
 pushd /etc/yum.repos.d/
   wget https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo
 popd


### PR DESCRIPTION
A part of https://github.com/ManageIQ/manageiq-appliance-build/issues/422

Requires https://github.com/ManageIQ/manageiq-rpm_build/pull/58 (and new rpm build with this change)