### PR TITLE
additional dependencies needed for installing python modules on ppc64le

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -1,5 +1,9 @@
 dnf install -y python3-pip libcurl-devel gcc libxml2-devel krb5-devel
 
+if [ `uname -m` = "ppc64le" ]; then
+  dnf install -y libffi-devel libxslt-devel openssl-devel make;
+fi
+
 # For Nuage
 pip3 install vspk==5.3.2
 


### PR DESCRIPTION
Reference https://github.com/ManageIQ/manageiq-rpm_build/issues/43