### PR TITLE
Add build type (release or nightly) support to container build

### DIFF
--- a/bin/container-build.sh
+++ b/bin/container-build.sh
@@ -23,7 +23,7 @@ rm -rf ${PODS_SOURCE_DIR}
 git clone -b ${1} https://github.com/ManageIQ/manageiq-pods ${PODS_SOURCE_DIR}
 
 pushd ${PODS_SOURCE_DIR}
-  env MIQ_REF=${1} SUI_REF=${1} APPLIANCE_REF=${1} BUILD_REF=${1} bin/build -n -p -d images -r manageiq -t ${tag}
+  env BUILD_REF=${1} bin/build -n -p -d images -r manageiq -t ${tag}
   bin/remove_images -r manageiq -t ${tag}
 popd
 

--- a/bin/container-build.sh
+++ b/bin/container-build.sh
@@ -1,34 +1,50 @@
 #!/bin/bash
-
 set -ex
 
-if [[ $# != 1 ]]; then
-  echo "Wrong number of arguments: $#. Usage example: container-build.sh <branch or tag>"
+while getopts "t:r:h" opt; do
+  case $opt in
+    t) BUILD_TYPE=$OPTARG ;;
+    r) REF=$OPTARG ;;
+    h) echo "Usage: $0 -t BUILD_TYPE -r REF [-h]"; exit 1
+  esac
+done
+
+if [ "$BUILD_TYPE" != "nightly" ] && [ "$BUILD_TYPE" != "release" ]; then
+  echo "Build type (-t) is required, must be either 'nightly' or 'release'"
   exit 1
 fi
 
-BRANCH=${1%%-*}
+if [ -z "$REF" ]; then
+  echo "ref (-r) is required"
+  exit 1
+fi
+
+BRANCH=${REF%%-*}
 PODS_SOURCE_DIR="/build/manageiq-pods-${BRANCH}"
 MANAGEIQ_SOURCE_DIR="/build/manageiq-${BRANCH}"
 
-if [ "${1}" = "master" ]; then
+if [ "${REF}" = "master" ]; then
   tag="latest"
-elif [ "${1}" != "${BRANCH}" ]; then # tag build
-  tag="${1}"
+elif [ "${REF}" != "${BRANCH}" ]; then # tag build
+  tag="${REF}"
 else # branch build
   tag="latest-${BRANCH}"
 fi
 
 rm -rf ${PODS_SOURCE_DIR}
-git clone -b ${1} https://github.com/ManageIQ/manageiq-pods ${PODS_SOURCE_DIR}
+git clone -b ${REF} https://github.com/ManageIQ/manageiq-pods ${PODS_SOURCE_DIR}
 
 pushd ${PODS_SOURCE_DIR}
-  env BUILD_REF=${1} bin/build -n -p -d images -r manageiq -t ${tag}
+  build_args="-n -p -d images -r manageiq -t ${tag}"
+  if [ "$BUILD_TYPE" == "release" ]; then
+    build_args+=" -s"
+  fi
+  env BUILD_REF=${REF} bin/build ${build_args}
   bin/remove_images -r manageiq -t ${tag}
 popd
 
 rm -rf ${MANAGEIQ_SOURCE_DIR}
-git clone -b ${1} --depth 1 https://github.com/ManageIQ/manageiq ${MANAGEIQ_SOURCE_DIR}
+git clone -b ${REF} --depth 1 https://github.com/ManageIQ/manageiq ${MANAGEIQ_SOURCE_DIR}
 
 pushd ${MANAGEIQ_SOURCE_DIR}
   docker build --no-cache -t manageiq/manageiq:${tag} --build-arg IMAGE_REF=${tag} .

--- a/bin/container-build.sh
+++ b/bin/container-build.sh
@@ -32,7 +32,7 @@ else # branch build
 fi
 
 rm -rf ${PODS_SOURCE_DIR}
-git clone -b ${REF} https://github.com/ManageIQ/manageiq-pods ${PODS_SOURCE_DIR}
+git clone -b ${REF} --depth 1 https://github.com/ManageIQ/manageiq-pods ${PODS_SOURCE_DIR}
 
 pushd ${PODS_SOURCE_DIR}
   build_args="-n -p -d images -r manageiq -t ${tag}"

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -35,11 +35,11 @@ then
 
   echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
   time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
-  time ${BUILD_DIR}/bin/container-build.sh ${BRANCH} 2>&1 | tee ${CONTAINER_LOG_FILE}
+  time ${BUILD_DIR}/bin/container-build.sh -t nightly -r ${BRANCH} 2>&1 | tee ${CONTAINER_LOG_FILE}
 else
   ( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH > ${RPM_LOG_FILE} 2>&1 &&
     ( nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
-      nohup time ${BUILD_DIR}/bin/container-build.sh ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 ) ) &
+      nohup time ${BUILD_DIR}/bin/container-build.sh -t nightly -r ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 ) ) &
 
   echo "Nightly Build kicked off, Logs @ ${LOG_DIR}/${BRANCH}_${DATE_STAMP}*.log..."
 fi

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -17,6 +17,6 @@ container_log_file="/build/logs/${1}_container.log"
 
 ( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t release -r ${1} > $rpm_log_file 2>&1;
   nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
-  nohup time ${BUILD_DIR}/bin/container-build.sh ${1} > $container_log_file 2>&1 ) &
+  nohup time ${BUILD_DIR}/bin/container-build.sh -t release -r ${1} > $container_log_file 2>&1 ) &
 
 echo "${1} release build kicked off, see logs @ /build/logs/${1}*.log ..."


### PR DESCRIPTION
Also changed to use getopts and removed environment variables (MIQ_REF, SUI_REF and APPLIANCE_REF) that are no longer used.

Requires https://github.com/ManageIQ/manageiq-pods/pull/597