### PR TITLE
Lower CPU and Memory

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -1,4 +1,4 @@
 {
   "generate_icicle": false,
-  "oz_overrides" : "{'libvirt': {'memory': 8192, 'cpus': 4}}"
+  "oz_overrides" : "{'libvirt': {'memory': 2048, 'cpus': 2}}"
 }


### PR DESCRIPTION
Now that a lot of the resource intensive work is moved out to rpm build, we can reduce the CPU/Memory settings.

Ran vmware and azure builds to verify build still works with this change.