### PR TITLE
Change ifcfg-en* to eth0 after all post processing tasks are completed

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -85,21 +85,6 @@ $APPLIANCE_SOURCE_DIRECTORY/manageiq-setup.sh
 
 <%= render_partial "post/db_init" %>
 
-# During the image build, dracut sets up ifcfg-en<whatever> for the device.
-# On the appliances we expect eth0, so remove all the ifcfg-en<whatever> device configurations 
-# and write a config for eth0 allowing the 'network' service to come up cleanly.
-rm -f /etc/sysconfig/network-scripts/ifcfg-en*
-
-cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
-DEVICE=eth0
-BOOTPROTO=dhcp
-ONBOOT=yes
-TYPE=Ethernet
-USERCTL=no
-NM_CONTROLLED=no
-DEFROUTE=yes
-EOF
-
 # Disable zeroconfig to allow access to meta-data service by cloud-init
 cat >> /etc/sysconfig/network << EOF
 NETWORKING=yes
@@ -145,6 +130,21 @@ done
 
 # Expire root password so that the appliance admin must change it at next login
 passwd -e root
+
+# During the image build, dracut sets up ifcfg-en<whatever> for the device.
+# On the appliances we expect eth0, so remove all the ifcfg-en<whatever> device configurations
+# and write a config for eth0 allowing the 'network' service to come up cleanly.
+rm -f /etc/sysconfig/network-scripts/ifcfg-en*
+
+cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
+DEVICE=eth0
+BOOTPROTO=dhcp
+ONBOOT=yes
+TYPE=Ethernet
+USERCTL=no
+NM_CONTROLLED=no
+DEFROUTE=yes
+EOF
 
 chvt 1
 ) 2>&1 | tee /dev/tty3


### PR DESCRIPTION
Some post processing tasks need network and replacing ifcfg-en* with ifcfg-eth0 too early causes an error. Moving that step to be the last step in %post section.

The error was noticed in azure image build as waagent deprovision process failed:
```
14:23:51,574 INFO anaconda:program: + [10:20:50] waagent -force -deprovision
...
14:23:51,574 INFO anaconda:program: 2020/08/19 10:20:51.513141 INFO Examine /proc/net/route for primary interface
14:23:51,574 INFO anaconda:program: 2020/08/19 10:20:51.523703 INFO Primary interface is [ens3]
14:23:51,575 INFO anaconda:program: 2020/08/19 10:20:51.541999 ERROR Failed to run 'deprovision': Traceback (most recent call last):
...
14:23:51,582 INFO anaconda:program: FileNotFoundError: [Errno 2] No such file or directory: '/etc/sysconfig/network-scripts/ifcfg-ens3'
```