### PR TITLE
Move vspk/pylxca python module installation to rpm requires

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -4,12 +4,6 @@ if [ `uname -m` = "ppc64le" ]; then
   dnf install -y libffi-devel libxslt-devel openssl-devel make;
 fi
 
-# For Nuage
-pip3 install vspk==5.3.2
-
-# For Lenovo
-pip3 install pylxca==2.1.1
-
 # For embedded ansible
 pip3 install virtualenv
 


### PR DESCRIPTION
Goes with https://github.com/ManageIQ/manageiq-rpm_build/pull/93 ~~and https://github.com/ManageIQ/manageiq-pods/pull/632~~