### PR TITLE
Remove machine-id

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -136,6 +136,9 @@ passwd -e root
 # and write a config for eth0 allowing the 'network' service to come up cleanly.
 rm -f /etc/sysconfig/network-scripts/ifcfg-en*
 
+# Remove machine-id
+cat /dev/null > /etc/machine-id
+
 cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
 DEVICE=eth0
 BOOTPROTO=dhcp


### PR DESCRIPTION
Remove machine iD from the images so it will be generated during boot.

https://bugzilla.redhat.com/show_bug.cgi?id=1889302