### PR TITLE
Allow for productization of build

### DIFF
--- a/bin/kickstart_build.rb
+++ b/bin/kickstart_build.rb
@@ -16,4 +16,5 @@ Build::KickstartGenerator.new(
   File.expand_path("..", __dir__),
   options[:type],
   options[:only],
+  options[:product_name],
   nil).run

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -18,3 +18,5 @@ repo --name=google-cloud-compute --baseurl=https://packages.cloud.google.com/yum
 
 # Please also add to "post install repos" post/repos partial
 repo --name=ansible-runner --baseurl=https://releases.ansible.com/ansible-runner/rpm/epel-8-x86_64/
+
+<%= render_partial_if_exist "main/repos-extra" %>

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -1,5 +1,5 @@
-manageiq-appliance
-manageiq-appliance-tools
+<%= @product_name %>-appliance
+<%= @product_name %>-appliance-tools
 
 epel-release
 manageiq-release

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -26,3 +26,5 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
 <% end %>
+
+<%= render_partial_if_exist "post/repos-extra" %>

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -5,13 +5,15 @@ require_relative 'target'
 module Build
   class Cli
     attr_reader :options
-    ALLOWED_TYPES = %w(nightly release test)
-    DEFAULT_TYPE  = "nightly"
-    DEFAULT_REF   = "master"
-    BUILD_URL     = "https://github.com/ManageIQ/manageiq-appliance-build.git"
+    ALLOWED_TYPES   = %w(nightly release test)
+    DEFAULT_TYPE    = "nightly"
+    DEFAULT_REF     = "master"
+    DEFAULT_PRODUCT = "manageiq"
+    BUILD_URL       = "https://github.com/ManageIQ/manageiq-appliance-build.git"
 
     def parse(args = ARGV)
       git_ref_desc   = "provide a git reference such as a branch or tag, non \"#{DEFAULT_REF}\" is required for 'release' type"
+      product_desc   = "product name.  Defaults to \"#{DEFAULT_PRODUCT}\"."
       type_desc      = "build type: nightly, release, test, a named yum repository"
       local_desc     = "Use local config and kickstart for build"
       dir_desc       = "Directory to copy builds to"
@@ -25,6 +27,7 @@ module Build
         opt :build_ref,     git_ref_desc,   :type => :string,  :short => "b", :default => nil
         opt :build_url,     build_desc,     :type => :string,  :short => "B", :default => BUILD_URL
         opt :reference,     git_ref_desc,   :type => :string,  :short => "r", :default => DEFAULT_REF
+        opt :product_name,  product_desc,   :type => :string,  :short => "p", :default => DEFAULT_PRODUCT
         opt :copy_dir,      dir_desc,       :type => :string,  :short => "d", :default => DEFAULT_REF
         opt :fileshare,     share_desc,     :type => :boolean, :short => "f", :default => true
         opt :local,         local_desc,     :type => :boolean, :short => "l", :default => false

--- a/scripts/productization.rb
+++ b/scripts/productization.rb
@@ -8,7 +8,7 @@ module Build
       build_dir  = Pathname.new(build_base)
       prod_file  = build_dir.join(PROD_DIR).join(path)
       build_file = build_dir.join(path)
-      File.exist?(prod_file) ? prod_file : build_file
+      [prod_file, build_file].detect { |f| File.exist?(f) }
     end
   end
 end

--- a/scripts/spec/cli_spec.rb
+++ b/scripts/spec/cli_spec.rb
@@ -34,6 +34,14 @@ describe Build::Cli do
       expect(described_class.new.parse(%w(--reference master -b branch_name)).options[:reference]).to eq("master")
     end
 
+    it "product_name (default)" do
+      expect(described_class.new.parse(%w()).options[:product_name]).to eq("manageiq")
+    end
+
+    it "product_name" do
+      expect(described_class.new.parse(%w(--product-name foo)).options[:product_name]).to eq("foo")
+    end
+
     it "release without reference" do
       expect { described_class.new.parse(%w(--type release)) }.to raise_error(SystemExit)
     end

--- a/scripts/spec/kickstart_generator_spec.rb
+++ b/scripts/spec/kickstart_generator_spec.rb
@@ -7,7 +7,7 @@ describe Build::KickstartGenerator do
     let(:generated)  { "#{build_base}/kickstarts/generated" }
     let(:ks_text)    { File.read("#{generated}/base-target.ks") }
 
-    subject { described_class.new(build_base, "release", ["target"], "puddle") }
+    subject { described_class.new(build_base, "release", ["target"], "manageiq", "puddle") }
 
     after do
       FileUtils.rm_rf(generated)

--- a/scripts/spec/productization_spec.rb
+++ b/scripts/spec/productization_spec.rb
@@ -12,5 +12,15 @@ describe Build::Productization do
       file = described_class.file_for(data_file_path("prod"), "test_no_prod")
       expect(file.to_s).not_to match(%r{productization/test_no_prod})
     end
+
+    it "finds the file when productization version exists but base file does not exist" do
+      file = described_class.file_for(data_file_path("prod"), "test_prod_but_not_base")
+      expect(file.to_s).to match(%r{productization/test_prod_but_not_base})
+    end
+
+    it "return nil when the file is not found at all" do
+      file = described_class.file_for(data_file_path("prod"), "test_not_found")
+      expect(file).to be_nil
+    end
   end
 end

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -80,11 +80,9 @@ hour_minute       = Time.now.strftime("%H%M")
 directory_name    = "#{year_month_day}_#{hour_minute}"
 timestamp         = "#{year_month_day}#{hour_minute}"
 
-name            = "manageiq"
-
 targets = cli_options[:only].collect { |only| Build::Target.new(only) }
 
-ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:type], cli_options[:only], puddle)
+ks_gen = Build::KickstartGenerator.new(cfg_base, cli_options[:type], cli_options[:only], cli_options[:product_name], puddle)
 ks_gen.run
 
 file_rdu_dir_base = FILE_SERVER_BASE.join(directory)
@@ -155,7 +153,7 @@ Dir.chdir(IMGFAC_DIR) do
     $log.info "Built #{target} with final UUID: #{uuid}"
 
     FileUtils.mkdir_p(destination_directory)
-    file_name = "#{name}-#{target}-#{build_label}-#{timestamp}.#{target.file_extension}"
+    file_name = "#{cli_options[:product_name]}-#{target}-#{build_label}-#{timestamp}.#{target.file_extension}"
     destination = destination_directory.join(file_name)
 
     Dir.chdir(STORAGE_DIR) do


### PR DESCRIPTION
@simaishi Please review

This PR adds
- the ability to pass the product name which is used to determine the rpm names as well as the built appliance name.
- the ability to specify extra repos via the productization directory under `main/repos-extra.ks.erb` and optionally `post/repos-extra.ks.erb`  (which is used when the rpm names are available elsewhere)

cc @bennett-white