### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
 - 2.6.6
 matrix: {}
 fast_finish: true
-sudo: false
 cache: bundler
 script: rake spec
 install: pushd scripts && bundle install --jobs=3 --retry=3 && popd


### PR DESCRIPTION
we can get rid of `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration