### PR TITLE
Allow passing any build arguments to nightly/release scripts

### DIFF
--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -21,24 +21,18 @@ CONTAINER_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_container.log"
 RPM_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_rpm.log"
 BUILD_OPTIONS="--type nightly --upload --reference ${BRANCH} --copy-dir ${BRANCH}"
 
-if [ "${1}" = "--fileshare" -o "${1}" = "--no-fileshare" -o "${1}" = "--local" ]
-then
-  BUILD_OPTIONS="$BUILD_OPTIONS ${1}"
-  shift
-fi
-
-if [ "${1}" = "--fg" ]
+if [ "${!#}" = "--fg" ]
 then
   echo "Nightly RPM build kicked off, Log being saved in ${RPM_LOG_FILE} ..."
   ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH 2>&1 |tee ${RPM_LOG_FILE}
   [ ${PIPESTATUS[0]} -ne 0 ] && exit 1
 
   echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
-  time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS 2>&1 | tee ${LOG_FILE}
+  time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS ${@:1:$#-1} 2>&1 | tee ${LOG_FILE}
   time ${BUILD_DIR}/bin/container-build.sh -t nightly -r ${BRANCH} 2>&1 | tee ${CONTAINER_LOG_FILE}
 else
   ( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH > ${RPM_LOG_FILE} 2>&1 &&
-    ( nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS >${LOG_FILE} 2>&1 &
+    ( nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS $@ >${LOG_FILE} 2>&1 &
       nohup time ${BUILD_DIR}/bin/container-build.sh -t nightly -r ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 ) ) &
 
   echo "Nightly Build kicked off, Logs @ ${LOG_DIR}/${BRANCH}_${DATE_STAMP}*.log..."

--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -6,17 +6,20 @@ BUILD_DIR="$(dirname "$(readlink -f "$0")")/.."
 source "${BUILD_DIR}/bin/shared_functions.sh"
 stop_on_existing_build
 
-if [[ $# != 1 ]]; then
-  echo "Wrong number of arguments: $#. Usage example: release-build.sh capablanca-1-alpha1"
+if [[ $# -lt 1 ]]; then
+  echo "Wrong number of arguments: $#. Usage example: release-build.sh capablanca-1-alpha1 [build options]"
   exit 1
 fi
+
+build_ref=${1}
+shift
 
 rpm_log_file="/build/logs/${1}_rpm.log"
 log_file="/build/logs/${1}.log"
 container_log_file="/build/logs/${1}_container.log"
 
-( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t release -r ${1} > $rpm_log_file 2>&1;
-  nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $1 --copy-dir ${1%%-*} > $log_file 2>&1 &
-  nohup time ${BUILD_DIR}/bin/container-build.sh -t release -r ${1} > $container_log_file 2>&1 ) &
+( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t release -r $build_ref > $rpm_log_file 2>&1;
+  nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $build_ref --copy-dir ${build_ref%%-*} $@ > $log_file 2>&1 &
+  nohup time ${BUILD_DIR}/bin/container-build.sh -t release -r $build_ref > $container_log_file 2>&1 ) &
 
-echo "${1} release build kicked off, see logs @ /build/logs/${1}*.log ..."
+echo "$build_ref release build kicked off, see logs @ /build/logs/${build_ref}*.log ..."


### PR DESCRIPTION
Currently, nightly script can only take 1 build option (either `fileshare`, `no-fileshare` or `local`) plus an option to run in foregrond, and release build can only take tag as argument.

Changing the scripts to take any build arguments, and that will:
* fix the issue where you can't use fileshare/non-fileshare and local at the same time for nightly build
* allow passing existing argments like product name
* not require modifying the scripts when new options get added