### PR TITLE
Add an option to delete artifacts after upload

### DIFF
--- a/scripts/cli.rb
+++ b/scripts/cli.rb
@@ -21,6 +21,7 @@ module Build
       build_desc     = "Repo URL containing the build config and kickstart"
       upload_desc    = "Upload appliance builds to the website"
       only_desc      = "Build only specific image types.  Example: --only ovirt openstack.  Defaults to all images."
+      delete_desc    = "Delete artifacts from fileshare after upload"
 
       @options = Optimist.options(args) do
         banner "Usage: build.rb [options]"
@@ -34,6 +35,7 @@ module Build
         opt :only,          only_desc,      :type => :strings, :short => "o", :default => Target.default_types
         opt :type,          type_desc,      :type => :string,  :short => "t", :default => DEFAULT_TYPE
         opt :upload,        upload_desc,    :type => :boolean, :short => "u", :default => false
+        opt :delete,        delete_desc,    :type => :boolean, :short => "e", :default => false
       end
 
       options[:type] &&= options[:type].strip

--- a/scripts/spec/uploader_spec.rb
+++ b/scripts/spec/uploader_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'uploader'
 
 describe Build::Uploader do
-  subject { described_class.new("directory", "type") }
+  subject { described_class.new("directory", "type", false) }
 
   it "#devel_filename" do
     expect(subject.send(:devel_filename, "manageiq-vsphere-master-20200213.ova")).to eq("manageiq-vsphere-devel.ova")

--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -234,5 +234,5 @@ if cli_options[:type] == "nightly" || cli_options[:type] == "release"
     $log.info("Created release ref link: #{result}")
   end
 
-  Build::Uploader.upload(destination_directory, cli_options[:type]) if cli_options[:upload]
+  Build::Uploader.upload(destination_directory, cli_options[:type], cli_options[:delete]) if cli_options[:upload]
 end


### PR DESCRIPTION
This is useful when running builds on an off-premise machine as artifacts are no longer needed on the machine once uploaded.

Need #457 to actually make a use of this in nightly builds.