### PR TITLE
[IVANCHUK] Lock bundler to v2.1.4

### DIFF
--- a/kickstarts/partials/post/bundler.ks.erb
+++ b/kickstarts/partials/post/bundler.ks.erb
@@ -6,7 +6,7 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 [[ -s /etc/default/evm ]] && source /etc/default/evm
-gem install bundler -v ">=1.8.4"
+gem install bundler -v 2.1.4
 
 ln -s ${APPLIANCE_SOURCE_DIRECTORY}/manageiq-appliance-dependencies.rb /var/www/miq/vmdb/bundler.d/manageiq-appliance-dependencies.rb
 


### PR DESCRIPTION
The latest version of bundler (2.2.4) doesn't work with the version of git available on CentOS 7. It's probably not a good idea to keep updating bundler on older branches anyway, so locking to 2.1.4 which is what was used in ivanchuk-7 release.

PR for podified build: https://github.com/ManageIQ/manageiq-pods/pull/667