### PR TITLE
Add starting the kafka server to the kickstart

### DIFF
--- a/kickstarts/partials/post/appliance_init.ks.erb
+++ b/kickstarts/partials/post/appliance_init.ks.erb
@@ -5,6 +5,8 @@ cat > /bin/appliance-initialize.sh <<EOF
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 echo "Initializing Appliance, please wait ..." > /dev/tty1
 appliance_console_cli --region 0 --internal --password smartvm --key
+appliance_console_cli --region 0 --internal --password smartvm --key
+appliance_console_cli --message-server-config --message-server-use-ipaddr --message-keystore-username="admin" --message-keystore-password="smartvm"
 EOF
 chmod 755 /bin/appliance-initialize.sh
 


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-appliance-build/issues/454

This PR adds starting the kafka server and it renames the db_init.ks.erb to appliance_init.ks.erb since it will be used to initialize more than just the db.