### PR TITLE
This file was renamed in #470

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -83,7 +83,7 @@ $APPLIANCE_SOURCE_DIRECTORY/manageiq-setup.sh
 
 <%= render_partial "post/systemd" %>
 
-<%= render_partial "post/db_init" %>
+<%= render_partial "post/appliance_init" %>
 
 # Disable zeroconfig to allow access to meta-data service by cloud-init
 cat >> /etc/sysconfig/network << EOF


### PR DESCRIPTION
Fixes:
```
/build/manageiq-appliance-build/scripts/kickstart_generator.rb:50:in `render': partial file "post/db_init" not found (ArgumentError)
	from /build/manageiq-appliance-build/scripts/kickstart_generator.rb:64:in `render_partial'
	from (erb):86:in `render'
	from /usr/share/ruby/erb.rb:876:in `eval'
	from /usr/share/ruby/erb.rb:876:in `result'
	from /build/manageiq-appliance-build/scripts/kickstart_generator.rb:56:in `render'
	from /build/manageiq-appliance-build/scripts/kickstart_generator.rb:60:in `evaluate_erb'
	from /build/manageiq-appliance-build/scripts/kickstart_generator.rb:31:in `block in run'
	from /build/manageiq-appliance-build/scripts/kickstart_generator.rb:28:in `each'
	from /build/manageiq-appliance-build/scripts/kickstart_generator.rb:28:in `run'
	from /build/manageiq-appliance-build/bin/../scripts/vmbuild.rb:86:in `<main>'
```