### PR TITLE
Fix log file names for release build script

### DIFF
--- a/bin/release-build.sh
+++ b/bin/release-build.sh
@@ -14,9 +14,9 @@ fi
 build_ref=${1}
 shift
 
-rpm_log_file="/build/logs/${1}_rpm.log"
-log_file="/build/logs/${1}.log"
-container_log_file="/build/logs/${1}_container.log"
+rpm_log_file="/build/logs/${build_ref}_rpm.log"
+log_file="/build/logs/${build_ref}.log"
+container_log_file="/build/logs/${build_ref}_container.log"
 
 ( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t release -r $build_ref > $rpm_log_file 2>&1;
   nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb --type release --upload --reference $build_ref --copy-dir ${build_ref%%-*} $@ > $log_file 2>&1 &


### PR DESCRIPTION
Currently:
```
[root@build-lasker manageiq-appliance-build]# /build/manageiq-appliance-build/bin/release-build.sh lasker-1-beta1
lasker-1-beta1 release build kicked off, see logs @ /build/logs/lasker-1-beta1*.log ...
```

But in the log directory:
```
-rw-r--r--.  1 root root   135657 Apr 20 17:28 _rpm.log
```