### PR TITLE
[WIP] introduce admin user

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -17,6 +17,8 @@ keyboard us
 
 # Root password: smartvm
 rootpw  --iscrypted $1$DZprqvCu$mhqFBjfLTH/PVvZIompVP/
+user --name=manageiq --groups=wheel --iscrypted --password $1$DZprqvCu$mhqFBjfLTH/PVvZIompVP/
+usermod -a -G manageiq root
 
 authconfig --enableshadow --passalgo=sha512
 selinux --enforcing

--- a/kickstarts/partials/post/appliance_init.ks.erb
+++ b/kickstarts/partials/post/appliance_init.ks.erb
@@ -5,6 +5,8 @@ cat > /bin/appliance-initialize.sh <<EOF
 [[ -s /etc/default/evm ]] && source /etc/default/evm
 echo "Initializing Appliance, please wait ..." > /dev/tty1
 appliance_console_cli --region 0 --internal --password smartvm --key
+chmod 440 /var/www/miq/vmdb/certs/v2_key
+chgrp manageiq /var/www/miq/vmdb/certs/v2_key
 appliance_console_cli --message-server-config --message-server-use-ipaddr --message-keystore-username="admin" --message-keystore-password="smartvm"
 EOF
 chmod 755 /bin/appliance-initialize.sh


### PR DESCRIPTION
The new manageiq user needs access to the v2_key -- so when the key is created, the
group is properly set.

This code is not fully tested. I need a little more work until I am able to build appliances on my local box and test the actual implementation of the kickstart, but this is what I typed on the command line.

To be honest, I'm not sure if the proper setup here is to chgrp the v2_key or to `chmod 2775` the directory to help others in the future with their `v2_key` endeavors.

