### PR TITLE
Ensure manageiq packages are up to date

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -117,6 +117,9 @@ echo "" >> /etc/ssh/sshd_config
 # Remove packages not needed
 dnf -C -y --noplugins remove linux-firmware doxygen
 
+# Ensure packages are up to date
+dnf -y update
+
 /usr/bin/generate_rpm_manifest.sh
 
 # CentOS 7.3 isn't clearing out spaces during install.


### PR DESCRIPTION
For some reason we're getting an up to date manageiq-appliance RPM but other manageiq-* RPMs are at older versions.  Force them to be updated to the latest available version.