### PR TITLE
Don't systemctl enable evm-watchdog

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -3,7 +3,6 @@ systemctl enable cloud-ds-check
 <% end %>
 
 systemctl enable cockpit.socket
-systemctl enable evm-watchdog
 systemctl enable evminit
 systemctl enable memcached
 systemctl enable miqtop


### PR DESCRIPTION
evm-watchdog was removed and replaced with a standard Restart=on-failure for evmserverd and manageiq-db-ready

https://github.com/ManageIQ/manageiq-appliance/pull/327