### PR TITLE
Don't enable postfix in the kickstart

### DIFF
--- a/kickstarts/partials/post/systemd.ks.erb
+++ b/kickstarts/partials/post/systemd.ks.erb
@@ -8,7 +8,6 @@ systemctl enable memcached
 systemctl enable miqtop
 systemctl enable miqvmstat
 systemctl enable network
-systemctl enable postfix
 
 # Link ctrl-alt-del.target to /dev/null to prevent reboot from console
 ln -sf /dev/null /etc/systemd/system/ctrl-alt-del.target


### PR DESCRIPTION
We're removing it in https://github.com/ManageIQ/manageiq-rpm_build/pull/202
People should use a real mail server, not a mail server hosted on our appliances.