### PR TITLE
Don't exclude alsa, it's causing appliance image builds to fail

### DIFF
--- a/kickstarts/partials/packages/excludes.ks.erb
+++ b/kickstarts/partials/packages/excludes.ks.erb
@@ -1,8 +1,5 @@
 # Excluded packages.
 
-# ALSA is not needed. We don't need to play sounds in our appliance.
--alsa-*
-
 # We don't need any firmware files. We always run as a virtual appliance, and
 # none of the virtual hardware devices implement by any of the major hypervisor
 # vendors needs firmware.


### PR DESCRIPTION
kafka requires jre 1.8
jre 1.8 requires libasound.so.2 which is provided by alsa-lib

```
19:46:14,279 WARNING anaconda:packaging:
 Problem: conflicting requests
  - package manageiq-appliance-14.0.0-20210908000050.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210909000027.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210909150854.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210910184617.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210910205409.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210913150740.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210915141115.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210923000029.el8.x86_64 requires kafka, but none of the providers can be installed
  - package manageiq-appliance-14.0.0-20210929165432.el8.x86_64 requires kafka, but none of the providers can be installed
  - package kafka-2.3.1-1.x86_64 requires jre >= 1.8, but none of the providers can be installed
  - package kafka-2.3.1-2.x86_64 requires jre >= 1.8, but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b01-0.3.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b01-0.3.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b01-0.3.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b02-0.0.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b02-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b02-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b03-0.0.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b03-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b03-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b04-0.0.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b04-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b04-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b08-0.el8_4.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b08-0.el8_4.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.302.b08-0.el8_4.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b01-0.3.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b01-0.3.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b01-0.3.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b02-0.0.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b02-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b02-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b03-0.0.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b03-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b03-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b04-0.0.ea.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b04-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b04-0.0.ea.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b08-0.el8_4.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b08-0.el8_4.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.302.b08-0.el8_4.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.292.b10-2.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.292.b10-2.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-1:1.8.0.292.b10-2.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.292.b10-2.el8.x86_64 requires libasound.so.2()(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.292.b10-2.el8.x86_64 requires libasound.so.2(ALSA_0.9)(64bit), but none of the providers can be installed
  - package java-1.8.0-openjdk-slowdebug-1:1.8.0.292.b10-2.el8.x86_64 requires libasound.so.2(ALSA_0.9.0rc4)(64bit), but none of the providers can be installed
  - package alsa-lib-1.2.4-5.el8.x86_64 is filtered out by exclude filtering
  - package alsa-lib-1.2.5-3.el8.x86_64 is filtered out by exclude filtering
  - package alsa-lib-1.2.5-4.el8.x86_64 is filtered out by exclude filtering
```