### PR TITLE
Upgrade to ruby 2.7

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -28,7 +28,7 @@ timezone --utc America/New_York
 
 module --name mod_auth_openidc
 module --name nodejs --stream 12
-module --name ruby --stream 2.6
+module --name ruby --stream 2.7
 
 reboot
 


### PR DESCRIPTION
Requires: https://github.com/ManageIQ/manageiq-rpm_build/pull/218