### PR TITLE
[MORPHY] Fix issue where the new branch might not have the updated repos

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -5,10 +5,10 @@ repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64
 repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
 repo --name=ovirt-4.4  --mirrorlist=https://resources.ovirt.org/pub/yum-repo/mirrorlist-ovirt-4.4-el$releasever
 
-repo --name=manageiq-12-lasker         --baseurl=https://rpm.manageiq.org/release/12-lasker/el$releasever/$basearch
-repo --name=manageiq-12-lasker-noarch  --baseurl=https://rpm.manageiq.org/release/12-lasker/el$releasever/noarch
+repo --name=manageiq-13-morphy         --baseurl=https://rpm.manageiq.org/release/13-morphy/el$releasever/$basearch
+repo --name=manageiq-13-morphy-noarch  --baseurl=https://rpm.manageiq.org/release/13-morphy/el$releasever/noarch
 <% if @build_type != "release" %>
-repo --name=manageiq-12-lasker-nightly --baseurl=https://rpm.manageiq.org/release/12-lasker-nightly/el$releasever/$basearch
+repo --name=manageiq-13-morphy-nightly --baseurl=https://rpm.manageiq.org/release/13-morphy-nightly/el$releasever/$basearch
 <% end %>
 
 <% if @target == "gce" %>


### PR DESCRIPTION
This change is similar to the one in https://github.com/ManageIQ/manageiq-rpm_build/pull/223.

While this doesn't actually break the build, it is inaccurate.

@bdunne Please review.

Note that 0b5ca2a9ddad4e5eb2686a4ba2587daeca7dcf12 will be forward-ported to master via cherry-pick after this is merged.