### PR TITLE
Installer issues

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -1,4 +1,4 @@
 {
   "generate_icicle": false,
-  "oz_overrides" : "{'libvirt': {'memory': 2048, 'cpus': 2}}"
+  "oz_overrides" : "{'libvirt': {'memory': 8192, 'cpus': 2}}"
 }

--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -6,7 +6,6 @@
 logging --level=debug
 
 #version=DEVEL
-install
 cdrom
 
 <%= render_partial "main/repos" %>


### PR DESCRIPTION
- Remove deprecated `install` command
- Increase installer RAM to get around issues before RPM installation