### PR TITLE
Add kernel parameter to prevent saving kickstart config

### DIFF
--- a/bin/iso_modify.sh
+++ b/bin/iso_modify.sh
@@ -29,6 +29,10 @@ rm -rf $WORKING
 
 implantisomd5 $DESTINATION
 
+ORIGINAL=$(echo $SOURCE | cut -d "." -f 1)-original.iso
+mv $SOURCE $ORIGINAL
+mv $DESTINATION $SOURCE
+
 set +e
 
 echo "Complete!"

--- a/bin/iso_modify.sh
+++ b/bin/iso_modify.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+SOURCE=$1
+WORKING=/tmp/remaster_iso_working
+DESTINATION=$(echo $SOURCE | cut -d "." -f 1)-modified.iso
+
+VOLUME_NAME=$(isoinfo -d -i $SOURCE | grep "Volume id:" | cut -d " " -f 3)
+
+SOURCE_DIR=/tmp/remaster_iso_source
+
+mkdir $SOURCE_DIR
+mount -o loop $SOURCE $SOURCE_DIR
+cp -ar $SOURCE_DIR $WORKING
+umount $SOURCE_DIR
+rm -rf $SOURCE_DIR
+
+pushd $WORKING
+  chmod -R u+w ./
+
+  sed -i '/append/ s/$/ inst.nosave=all/' isolinux/isolinux.cfg
+
+  mkisofs -o $DESTINATION -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -joliet-long -V "$VOLUME_NAME" -R -J -v -T .
+
+popd
+
+rm -rf $WORKING
+
+implantisomd5 $DESTINATION
+
+set +e
+
+echo "Complete!"


### PR DESCRIPTION
Secrets in the kickstart config were being saved to the appliance

This script will extract the ISO, add the `inst.nosave=all` kernel parameter, rebuild the ISO and clean up.  Please run this script against any source ISO that will be used for builds with secrets in the kickstart.

Note: This does not protect us from exposing any secrets in the post-install script
https://access.redhat.com/solutions/2740121