### PR TITLE
Add ability to inspect the ISO for kickstart logging

### DIFF
--- a/bin/iso_modify.sh
+++ b/bin/iso_modify.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+SOURCE=$1
+
+# Check if the ISO is already modified
+if [ -n "$ENSURE_ISO_KICKSTART_LOGGING_DISABLED" -a -z "$(isoinfo -J -i $SOURCE -x /isolinux/isolinux.cfg | grep append | grep -v "inst\.nosave=all")" ]; then
+  echo "'$SOURCE' has already been modified."
+  exit 0
+fi
+
 set -e
 
-SOURCE=$1
+echo "Modifying '$SOURCE'..."
+
 WORKING=/tmp/remaster_iso_working
 DESTINATION=$(echo $SOURCE | cut -d "." -f 1)-modified.iso
 
@@ -35,4 +44,4 @@ mv $DESTINATION $SOURCE
 
 set +e
 
-echo "Complete!"
+echo "Modifying '$SOURCE'...Complete!"

--- a/config/base.tdl.erb
+++ b/config/base.tdl.erb
@@ -6,7 +6,7 @@
     <version>4</version>
     <arch>x86_64</arch>
     <install type="iso">
-      <iso>file:///build/isos/CentOS-Stream-8-x86_64-20211206-dvd1.iso</iso>
+      <iso>file://<%= ISO_FILE.to_s %></iso>
     </install>
   </os>
   <description>CentOS TDL meant to be used with custom kickstart for manageiq.</description>


### PR DESCRIPTION
@bdunne Please review.

~~Expected usage is that if someone doesn't want kickstart logging, they can pass `--no-ks-log` to vmbuild~~

~~I intentionally made the iso_modified.sh a shell script to mirror iso_modify.sh.  That way after someone manually changes it with iso_modify.sh, they can check it with iso_modified.sh in a similar way.~~

As dicsussed, I've changed the iso_modify.sh to first check if modified, and then we just always call it from the build.  Specific modifications can be opted out with ENV vars.
