### PR TITLE
[MORPHY] Move to CentOS Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ Below are instructions on configuring a dedicated build machine to generate appl
   ```
   #!ipxe
 
-  kernel http://pxeserver.example.com/sources/centos/8/vmlinuz inst.ks=http://pxeserver.example.com/ipxe/mac/centos8_build_machine.ks net.ifnames=0 biosdevname=0
+  kernel http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/isolinux/vmlinuz inst.ks=http://pxeserver.example.com/ipxe/mac/centos8_build_machine.ks net.ifnames=0 biosdevname=0
   #ramdisk_size=10000
-  initrd http://pxeserver.example.com/sources/centos/8/initrd.img
+  initrd http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/isolinux/initrd.img
   boot
   ```
 ## Download CentOS 8 ISO
-  * Download latest CentOS 8 ISO from http://isoredirect.centos.org/centos/8/isos/x86_64/
+  * Download latest CentOS 8 ISO from http://isoredirect.centos.org/centos/8-stream/isos/x86_64/
     ```
-    curl -L http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8.1.1911-x86_64-dvd1.iso \
-      -o /build/isos/CentOS-8.1.1911-x86_64-dvd1.iso
+    curl -L http://isoredirect.centos.org/centos/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-20210608-dvd1.iso \
+      -o /build/isos/CentOS-Stream-8-x86_64-20210608-dvd1.iso
     ```
     
 ## Setup docker for container build

--- a/kickstarts/centos8_build_machine.ks
+++ b/kickstarts/centos8_build_machine.ks
@@ -21,11 +21,11 @@ reboot
 graphical
 
 # Use network installation
-url --url="http://mirror.centos.org/centos/8/BaseOS/x86_64/os/"
-repo --name="AppStream" --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
-repo --name="PowerTools" --baseurl=http://mirror.centos.org/centos/8/PowerTools/x86_64/os/
-repo --name="extras" --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
-repo --name="epel" --baseurl=https://mirror.atl.genesisadaptive.com/epel//8/Everything/x86_64/
+url --url="http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+repo --name="AppStream" --baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+repo --name="PowerTools" --baseurl=http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/
+repo --name="extras" --baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
+repo --name="epel" --baseurl=https://download.fedoraproject.org/pub/epel/8/Everything/x86_64/
 repo --name="ManageIQ-Build" --baseurl=https://copr-be.cloud.fedoraproject.org/results/manageiq/ManageIQ-Build/epel-8-x86_64/
 
 keyboard --vckeymap=us --xlayouts='us'

--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -1,7 +1,7 @@
 # build time repos - these repos are used to install the initial packages
-repo --name=baseos     --baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
-repo --name=appstream  --baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
-repo --name=extras     --baseurl=http://mirror.centos.org/centos/8/extras/x86_64/os/
+repo --name=baseos     --baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
+repo --name=appstream  --baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
+repo --name=extras     --baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
 repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
 repo --name=ovirt-4.4  --mirrorlist=https://resources.ovirt.org/pub/yum-repo/mirrorlist-ovirt-4.4-el$releasever
 


### PR DESCRIPTION
Manual backport of #481

While the CentOS 8 repos are still available, CentOS 8 is EOL and we've already switched to using the Stream ISO.
Specifically, the latest version of postgresql-server available in the old repo is 10.17 and the stream repo contains 10.19.