### PR TITLE
Don't automatically initialize appliances

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -23,7 +23,6 @@ timezone --utc America/New_York
 
 <%= render_partial "main/bootloader" %>
 <%= render_partial "main/disk_layout" %>
-<%= render_partial "main/db_fs" %>
 
 module --name mod_auth_openidc
 module --name ruby --stream 2.7

--- a/kickstarts/partials/main/db_fs.ks.erb
+++ b/kickstarts/partials/main/db_fs.ks.erb
@@ -1,3 +1,0 @@
-part pv.2             --ondrive=vda                     --size=10240 --grow
-volgroup vg_data      --pesize=4096 pv.2
-logvol /var/lib/pgsql --name=lv_pg --vgname=vg_data --size=8192 --grow --fstype=xfs

--- a/kickstarts/partials/post/appliance_init.ks.erb
+++ b/kickstarts/partials/post/appliance_init.ks.erb
@@ -1,1 +1,0 @@
-systemctl enable manageiq-initialize

--- a/scripts/spec/target_spec.rb
+++ b/scripts/spec/target_spec.rb
@@ -25,7 +25,7 @@ describe Build::Target do
   end
 
   it "#image_size" do
-    expect(described_class.new("openstack").image_size).to eql "66"
+    expect(described_class.new("openstack").image_size).to eql "58"
   end
 
   it "#sort" do

--- a/scripts/target.rb
+++ b/scripts/target.rb
@@ -3,15 +3,15 @@ module Build
     ImagefactoryMetadata = Struct.new(:imagefactory_type, :ova_format, :file_extension, :compression_type, :image_size)
 
     TYPES = {
-      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil, '66'),
-      'ovirt'     => ImagefactoryMetadata.new('rhevm', nil, 'qc2', 'qemu-qcow2', '66'),
-      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
-      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip', '66'),
-      'azure'     => ImagefactoryMetadata.new(nil, nil, 'vhd', 'zip', '61'),
-      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil, '66'),
-      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '66'),
-      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil, '66'),
-      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip', '66'),
+      'vsphere'   => ImagefactoryMetadata.new('vsphere', 'vsphere', 'ova', nil, '58'),
+      'ovirt'     => ImagefactoryMetadata.new('rhevm', nil, 'qc2', 'qemu-qcow2', '58'),
+      'openstack' => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '58'),
+      'hyperv'    => ImagefactoryMetadata.new('hyperv', nil, 'vhd', 'zip', '58'),
+      'azure'     => ImagefactoryMetadata.new(nil, nil, 'vhd', 'zip', '53'),
+      'vagrant'   => ImagefactoryMetadata.new('vsphere', 'vagrant-virtualbox', 'box', nil, '58'),
+      'libvirt'   => ImagefactoryMetadata.new('openstack-kvm', nil, 'qc2', nil, '58'),
+      'gce'       => ImagefactoryMetadata.new('gce', nil, 'tar.gz', nil, '58'),
+      'ec2'       => ImagefactoryMetadata.new('ec2', nil, 'vhd', 'zip', '58'),
     }
 
     attr_reader :name


### PR DESCRIPTION
For demo purposes it is nice to have an appliance which automatically initializes itself on boot, but this makes it quite difficult to use these images in a production deployment which requires multiple appliances.

This removes the auto-initialization on first-boot allowing the user to use appliance_console to connect the appliance to an existing region or create a new one.

Follow-up:
* Remove `manageiq-initialize.service` from manageiq-appliance - https://github.com/ManageIQ/manageiq-appliance/pull/359
* Document configuring kafka - https://github.com/ManageIQ/manageiq-documentation/pull/1675
* Reduce the root disk size for the image builds