### PR TITLE
Nodejs is no longer a runtime dependency

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -26,7 +26,6 @@ timezone --utc America/New_York
 <%= render_partial "main/db_fs" %>
 
 module --name mod_auth_openidc
-module --name nodejs --stream 14
 module --name ruby --stream 2.7
 
 reboot


### PR DESCRIPTION
As of https://github.com/ManageIQ/manageiq-rpm_build/pull/282 and
https://github.com/ManageIQ/manageiq-ui-classic/pull/8320
nodejs is a build time dependency to build the rpms and minify the assets but is
not needed a runtime.

For https://github.com/ManageIQ/manageiq-ui-classic/issues/8300

NOTE: See https://github.com/ManageIQ/manageiq-ui-classic/issues/8300 for the breakdown of required PRs.