### PR TITLE
Update certain python dependencies for CVEs

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -68,13 +68,13 @@ idna==2.6
 ipaddress==1.0.19
 iso8601==0.1.12
 isodate==0.6.0
-Jinja2==2.10.1
+Jinja2==2.11.3 # Match the system python38-jinja2 version
 jmespath==0.9.3
 jsonpatch==1.21
 jsonpointer==2.0
 keystoneauth1==3.11.2
 knack==0.3.3
-lxml==4.1.1
+lxml==4.9.1
 MarkupSafe==1.1.1
 monotonic==1.4
 msrest==0.6.1
@@ -89,7 +89,7 @@ openstacksdk==0.23.0
 os-service-types==1.2.0
 ovirt-engine-sdk-python==4.2.4
 packaging==17.1
-paramiko==2.4.2
+paramiko==2.10.1
 pbr==3.1.1
 pexpect==4.6.0
 psutil==5.6.6 # Match the version installed directly into the venv
@@ -97,7 +97,7 @@ ptyprocess==0.5.2
 pyasn1==0.4.2
 pyasn1-modules==0.2.3
 pycparser==2.18
-Pygments==2.2.0
+Pygments==2.7.4
 PyJWT==1.6.0
 pykerberos==1.2.1
 PyNaCl==1.2.1
@@ -106,8 +106,8 @@ pyparsing==2.2.0
 python-dateutil==2.6.1
 pyvmomi==6.5
 pywinrm==0.3.0
-PyYAML==5.4
-requests==2.20.0
+PyYAML==5.4.1 # Match the system python38-pyyaml version
+requests==2.25.1
 requests-credssp==0.1.0
 requests-kerberos==0.12.0
 requests-ntlm==1.1.0
@@ -118,7 +118,7 @@ selectors2==2.0.1
 six==1.11.0
 stevedore==1.28.0
 tabulate==0.7.7
-urllib3==1.24.3
+urllib3==1.26.5
 xmltodict==0.11.0
 EOF
 


### PR DESCRIPTION
- Bump pygments to 2.7.4 for CVE-2021-20270 and CVE-2021-27291
- Bump urllib3 to 1.26.5 for CVE-2021-33503
  - This required bumping requests to 2.25.1
- Bump lxml to 4.9.1 for CVE-2018-19787, CVE-2020-27783, CVE-2021-28957,
  CVE-2021-43818, and CVE-2022-2309
- Bump jinja2 to 2.11.3 for CVE-2020-28493
- Bump paramiko to 2.10.1 for CVE-2022-24302

Also be more explicit for PyYAML to match the installed package

@agrare Please review.  I verified with the vsphere.yml and the hello_world.yml on the docker images