### PR TITLE
Update certain python dependencies for CVEs

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -84,7 +84,7 @@ ncclient==0.6.3
 netaddr==0.7.19
 netifaces==0.10.6
 ntlm-auth==1.0.6
-oauthlib==2.0.6
+oauthlib==3.2.0
 openstacksdk==0.23.0
 os-service-types==1.2.0
 ovirt-engine-sdk-python==4.2.4
@@ -98,7 +98,7 @@ pyasn1==0.4.2
 pyasn1-modules==0.2.3
 pycparser==2.18
 Pygments==2.7.4
-PyJWT==1.6.0
+PyJWT==2.4.0
 pykerberos==1.2.1
 PyNaCl==1.2.1
 pyOpenSSL==17.5.0
@@ -109,7 +109,7 @@ pywinrm==0.3.0
 PyYAML==5.4.1 # Match the system python38-pyyaml version
 requests==2.25.1
 requests-credssp==0.1.0
-requests-kerberos==0.12.0
+requests-kerberos==0.14.0
 requests-ntlm==1.1.0
 requests-oauthlib==0.8.0
 requestsexceptions==1.4.0


### PR DESCRIPTION
- oauthlib to 3.2.0 for PRISMA-2021-0041
- pyjwt to 2.4.0 for CVE-2022-29217
- requests-kerberos for PRISMA-2021-0161

@agrare Please review.  I've tested with the hello world and the vsphere.yml, and they work.