### PR TITLE
Remove transitive dependencies from the list of python packages

### DIFF
--- a/kickstarts/partials/post/python_modules.ks.erb
+++ b/kickstarts/partials/post/python_modules.ks.erb
@@ -9,15 +9,9 @@ pushd /var/lib/manageiq
   source venv/bin/activate
 
   cat > requirements.txt << EOF
-adal==1.2.1
 apache-libcloud==2.5.0
-appdirs==1.4.3
-applicationinsights==0.11.1
-argcomplete==1.9.4
 asn1crypto==0.24.0
 azure-cli-core==2.0.35
-azure-cli-nspkg==3.0.2
-azure-common==1.1.11
 azure-graphrbac==0.40.0
 azure-keyvault==1.0.0a1
 azure-mgmt-authorization==0.51.1
@@ -45,84 +39,30 @@ azure-mgmt-sql==0.10.0
 azure-mgmt-storage==3.1.0
 azure-mgmt-trafficmanager==0.50.0
 azure-mgmt-web==0.41.0
-azure-nspkg==2.0.0
 azure-storage==0.35.1
 backports.ssl-match-hostname==3.5.0.1
-bcrypt==3.1.4
 boto==2.47.0
 boto3==1.6.2
-botocore==1.9.3
-cachetools==3.0.0
-certifi==2018.1.18
-cffi==1.14.6
-chardet==3.0.4
-colorama==0.3.9
-cryptography==2.8 # Match the system python38-cryptography version
-decorator==4.2.1
 deprecation==2.0
-docutils==0.14
-dogpile.cache==0.6.5
 google-auth==1.6.2
-humanfriendly==4.8
-idna==2.6
 ipaddress==1.0.19
-iso8601==0.1.12
-isodate==0.6.0
-Jinja2==2.11.3 # Match the system python38-jinja2 version
-jmespath==0.9.3
-jsonpatch==1.21
-jsonpointer==2.0
-keystoneauth1==3.11.2
-knack==0.3.3
-lxml==4.9.1
-MarkupSafe==1.1.1
 monotonic==1.4
-msrest==0.6.1
-msrestazure==0.5.0
-munch==2.2.0
 ncclient==0.6.3
 netaddr==0.7.19
-netifaces==0.10.6
-ntlm-auth==1.0.6
-oauthlib==3.2.0
 openstacksdk==0.23.0
-os-service-types==1.2.0
 ovirt-engine-sdk-python==4.2.4
-packaging==17.1
-paramiko==2.10.1
-pbr==3.1.1
 pexpect==4.6.0
 psutil==5.6.6 # Match the version installed directly into the venv
-ptyprocess==0.5.2
-pyasn1==0.4.2
-pyasn1-modules==0.2.3
-pycparser==2.18
-Pygments==2.7.4
-PyJWT==2.4.0
 pykerberos==1.2.1
-PyNaCl==1.2.1
-pyOpenSSL==17.5.0
-pyparsing==2.2.0
-python-dateutil==2.6.1
 pyvmomi==6.5
 pywinrm==0.3.0
-PyYAML==5.4.1 # Match the system python38-pyyaml version
 requests==2.25.1
 requests-credssp==0.1.0
 requests-kerberos==0.14.0
-requests-ntlm==1.1.0
-requests-oauthlib==0.8.0
-requestsexceptions==1.4.0
-s3transfer==0.1.13
-selectors2==2.0.1
-six==1.11.0
-stevedore==1.28.0
-tabulate==0.7.7
-urllib3==1.26.5
-xmltodict==0.11.0
 EOF
 
   pip3.8 install -r requirements.txt
+  pip3.8 list --format freeze > installed.txt
 
   deactivate
 popd


### PR DESCRIPTION
The packages in this commit will still be installed, but we let pip do the resolutions.  This will keep those packages up to date.

The following is a diff showing before/after of what's installed:

```diff
@@ -1,14 +1,15 @@
-adal==1.2.1
+adal==1.2.7
 ansible==5.4.0
 ansible-core==2.12.7
 apache-libcloud==2.5.0
-appdirs==1.4.3
-applicationinsights==0.11.1
-argcomplete==1.9.4
+appdirs==1.4.4
+applicationinsights==0.11.10
+argcomplete==2.0.0
 asn1crypto==0.24.0
 azure-cli-core==2.0.35
-azure-cli-nspkg==3.0.2
-azure-common==1.1.11
+azure-cli-nspkg==3.0.4
+azure-common==1.1.28
+azure-core==1.25.1
 azure-graphrbac==0.40.0
 azure-keyvault==1.0.0a1
 azure-mgmt-authorization==0.51.1
@@ -36,73 +37,73 @@ azure-mgmt-sql==0.10.0
 azure-mgmt-storage==3.1.0
 azure-mgmt-trafficmanager==0.50.0
 azure-mgmt-web==0.41.0
-azure-nspkg==2.0.0
+azure-nspkg==3.0.2
 azure-storage==0.35.1
 Babel==2.7.0
 backports.ssl-match-hostname==3.5.0.1
-bcrypt==3.1.4
+bcrypt==4.0.0
 boto==2.47.0
 boto3==1.6.2
-botocore==1.9.3
-cachetools==3.0.0
-certifi==2018.1.18
-cffi==1.14.6
-chardet==3.0.4
-colorama==0.3.9
-cryptography==2.8
-decorator==4.2.1
+botocore==1.9.23
+cachetools==5.2.0
+certifi==2022.6.15.1
+cffi==1.13.2
+chardet==4.0.0
+colorama==0.4.5
+cryptography==38.0.1
+decorator==5.1.1
 deprecation==2.0
 distlib==0.3.6
-docutils==0.14
-dogpile.cache==0.6.5
+docutils==0.19
+dogpile.cache==1.1.8
 filelock==3.8.0
 google-auth==1.6.2
 gssapi==1.8.1
-humanfriendly==4.8
-idna==2.6
+humanfriendly==10.0
+idna==2.8
 ipaddress==1.0.19
-iso8601==0.1.12
-isodate==0.6.0
+iso8601==1.0.2
+isodate==0.6.1
 Jinja2==2.11.3
-jmespath==0.9.3
-jsonpatch==1.21
-jsonpointer==2.0
-keystoneauth1==3.11.2
+jmespath==0.10.0
+jsonpatch==1.32
+jsonpointer==2.3
+keystoneauth1==5.0.0
 knack==0.3.3
 krb5==0.3.0
 lxml==4.9.1
 MarkupSafe==1.1.1
 monotonic==1.4
-msrest==0.6.1
-msrestazure==0.5.0
-munch==2.2.0
+msrest==0.7.1
+msrestazure==0.6.4
+munch==2.5.0
 ncclient==0.6.3
 netaddr==0.7.19
-netifaces==0.10.6
-ntlm-auth==1.0.6
-oauthlib==3.2.0
+netifaces==0.11.0
+ntlm-auth==1.5.0
+oauthlib==3.2.1
 openstacksdk==0.23.0
-os-service-types==1.2.0
+os-service-types==1.7.0
 ovirt-engine-sdk-python==4.2.4
-packaging==17.1
-paramiko==2.10.1
-pbr==3.1.1
+packaging==21.3
+paramiko==2.11.0
+pbr==5.10.0
 pexpect==4.6.0
 pip==22.2.2
 platformdirs==2.5.2
 ply==3.11
 psutil==5.6.6
-ptyprocess==0.5.2
-pyasn1==0.4.2
-pyasn1-modules==0.2.3
-pycparser==2.18
+ptyprocess==0.7.0
+pyasn1==0.4.8
+pyasn1-modules==0.2.8
+pycparser==2.19
 pycurl==7.45.1
-Pygments==2.7.4
+Pygments==2.13.0
 PyJWT==2.4.0
 pykerberos==1.2.1
-PyNaCl==1.2.1
-pyOpenSSL==17.5.0
-pyparsing==2.2.0
+PyNaCl==1.5.0
+pyOpenSSL==22.0.0
+pyparsing==3.0.9
 pyspnego==0.6.0
 python-dateutil==2.6.1
 pytz==2019.3
@@ -113,17 +114,18 @@ requests==2.25.1
 requests-credssp==0.1.0
 requests-kerberos==0.14.0
 requests-ntlm==1.1.0
-requests-oauthlib==0.8.0
+requests-oauthlib==1.3.1
 requestsexceptions==1.4.0
 resolvelib==0.5.4
 rsa==4.9
 s3transfer==0.1.13
-selectors2==2.0.1
+selectors2==2.0.2
 setuptools==65.3.0
-six==1.11.0
-stevedore==1.28.0
-tabulate==0.7.7
-urllib3==1.26.5
+six==1.12.0
+stevedore==4.0.0
+tabulate==0.8.2
+typing_extensions==4.3.0
+urllib3==1.26.12
 virtualenv==20.16.5
 wheel==0.30.0
-xmltodict==0.11.0
+xmltodict==0.13.0
```

---

@agrare Please review.  I verified with the hello_world.yml and vsphere.yml playbooks.