### PR TITLE
Update appliances to use ruby 3

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -25,7 +25,7 @@ timezone --utc America/New_York
 <%= render_partial "main/disk_layout" %>
 
 module --name mod_auth_openidc
-module --name ruby --stream 2.7
+module --name ruby --stream 3.0
 
 reboot
 


### PR DESCRIPTION
~~Depends on ruby 3 support from https://github.com/ManageIQ/manageiq/pull/21531~~ MERGED 🎉 
Depends on https://github.com/ManageIQ/manageiq-rpm_build/pull/304 for ruby 3 rpm builds
