### PR TITLE
Exclude epel-next-release rpm from being installed

### DIFF
--- a/kickstarts/partials/packages/excludes.ks.erb
+++ b/kickstarts/partials/packages/excludes.ks.erb
@@ -11,3 +11,4 @@
 # Misc other things we do not need.
 -gcc-gfortran
 -dracut-fips
+-epel-next-release


### PR DESCRIPTION
epel-next-release can prematurely bring in newer versions of packages we aren't prepared for, so exclude it.

@agrare Please review.