### PR TITLE
Bump up to 12GB RAM

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -1,4 +1,4 @@
 {
   "generate_icicle": false,
-  "oz_overrides" : "{'libvirt': {'memory': 8192, 'cpus': 2}}"
+  "oz_overrides" : "{'libvirt': {'memory': 12280, 'cpus': 2}}"
 }


### PR DESCRIPTION
In testing, I used 10GB and still used some swap.  This should give a little bit of ead room and avoid the "OSError: Cannot allocate memory" issues.