### PR TITLE
Drop build memory back to 4GB

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -1,4 +1,4 @@
 {
   "generate_icicle": false,
-  "oz_overrides" : "{'libvirt': {'memory': 12280, 'cpus': 2}}"
+  "oz_overrides" : "{'libvirt': {'memory': 4096, 'cpus': 2}}"
 }


### PR DESCRIPTION
We are hitting memory issues on the build machine where it tries to run multiple builds at the same time, but it can not allocate memory because the host system is out of memory.  In a few test installations, I was able to run an install with the current kickstart and the guest would go slightly into swap during package installation, but the install completed successfully and speed was not significantly different.

Error:
```
2023-03-20 05:43:35,280 ERROR imgfac.Builder.Builder thread(880bbd37) Message: Exception encountered in _build_image_from_template thread 2023-03-20 05:43:35,280 ERROR imgfac.Builder.Builder thread(880bbd37) Message: internal error: process exited while connecting to monitor: 2023-03-20T09:43:33.265855Z qemu-kvm: cannot set up guest memory 'pc.ram': Cannot allocate memory Traceback (most recent call last):
  File "/build/imagefactory/imgfac/Builder.py", line 135, in _build_image_from_template
    self.os_plugin.create_base_image(self, template, parameters)
  File "/build/imagefactory/imagefactory_plugins/TinMan/TinMan.py", line 344, in create_base_image
    libvirt_xml = self.guest.install(self.app_config["timeout"])
  File "/usr/lib/python3.6/site-packages/oz/RedHat.py", line 717, in install
    self.virtio_channel_name)
  File "/usr/lib/python3.6/site-packages/oz/Guest.py", line 1601, in _do_install
    self._wait_for_install_finish(xml, timeout)
  File "/usr/lib/python3.6/site-packages/oz/Guest.py", line 773, in _wait_for_install_finish
    libvirt_dom = self.libvirt_conn.createXML(xml, 0)
  File "/usr/lib64/python3.6/site-packages/libvirt.py", line 4400, in createXML
    raise libvirtError('virDomainCreateXML() failed')
libvirt.libvirtError: internal error: process exited while connecting to monitor: 2023-03-20T09:43:33.265855Z qemu-kvm: cannot set up guest memory 'pc.ram': Cannot allocate memory E, [2023-03-20T05:43:35.358899 #414647] ERROR -- : Could not find UUID. Skipping...
```