### PR TITLE
authconfig is deprecated in favor of authselect

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -17,7 +17,6 @@ keyboard us
 # Root password: smartvm
 rootpw  --iscrypted $1$DZprqvCu$mhqFBjfLTH/PVvZIompVP/
 
-authconfig --enableshadow --passalgo=sha512
 selinux --enforcing
 timezone --utc America/New_York
 


### PR DESCRIPTION
https://docs.centos.org/en-US/8-docs/advanced-install/assembly_kickstart-commands-and-options-reference/#auth-or-authconfig-deprecated_kickstart-commands-for-system-configuration

In https://www.mankier.com/7/authselect-migration there's a note that says:
Authconfig options --enableshadow and --passalgo=sha512 were often used to make sure that passwords are stored in /etc/shadow using sha512 algorithm. The authselect profiles now use the yescrypt hashing method and it cannot be changed through an option (only by creating a custom profile). You can just omit these options.