### PR TITLE
Add a script that can be run by cron to clean up factory build vms

### DIFF
--- a/bin/clean_dead_factory_build_vms.sh
+++ b/bin/clean_dead_factory_build_vms.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+killing_time=8000
+running_factory_build_ids=$(virsh list | sed -nE "s|\s([0-9]+)\s+factory-build-.*|\1|p") || exit $?
+
+for id in $running_factory_build_ids
+do
+  echo "Checking id: $id"
+  dominfo=$(virsh dominfo $id) || exit $?
+  dom_running_time_s=$(echo $dominfo | sed -nE 's|.*CPU time:\s+([0-9]+).*|\1|p') || exit $?
+  echo "  running seconds: $dom_running_time_s"
+  if [[ $dom_running_time_s -gt $killing_time ]]
+  then
+    echo "  Killing $id"
+    virsh destroy $id
+  else
+    echo "  Running for less than $killing_time seconds, skipping."
+  fi
+done


### PR DESCRIPTION
If something goes wrong in the VM build process, ImageFactory will give up after 7200 seconds.  It doesn't clean up that VM, it just takes a screenshot. If too mnay running VMs are left around it causes problems for new builds since the host can run out of memory.

CPU time is not perfect, but it should be good enough.