### PR TITLE
Add an XML parser for aws-sdk-s3

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem "activesupport"
 gem "awesome_spawn"
 gem "aws-sdk-s3"
+gem "nokogiri"
 gem "optimist"
 gem "rest-client", "~> 2.1"
 


### PR DESCRIPTION
I, [2023-05-19T01:04:52.414267 #4113]  INFO -- : Compressing manageiq-azure-master-202305181547.vhd to /build/fileshare/master/20230518_1547/manageiq-azure-master-202305181547.zip /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml/parser.rb:74:in `set_default_engine': Unable to find a compatible xml library. Ensure that you have installed or added to your Gemfile one of ox, oga, libxml, nokogiri or rexml (RuntimeError)
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml/parser.rb:96:in `<class:Parser>'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml/parser.rb:7:in `<module:Xml>'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml/parser.rb:5:in `<module:Aws>'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml/parser.rb:3:in `<top (required)>'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml.rb:8:in `require_relative'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core/xml.rb:8:in `<top (required)>'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core.rb:77:in `require_relative'
	from /usr/share/gems/gems/aws-sdk-core-3.171.0/lib/aws-sdk-core.rb:77:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /usr/share/gems/gems/aws-sdk-kms-1.63.0/lib/aws-sdk-kms.rb:11:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /usr/share/gems/gems/aws-sdk-s3-1.119.2/lib/aws-sdk-s3.rb:11:in `<top (required)>'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:160:in `require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from /build/manageiq-appliance-build/scripts/uploader.rb:117:in `client'
	from /build/manageiq-appliance-build/scripts/uploader.rb:88:in `block in upload'
	from /build/manageiq-appliance-build/scripts/uploader.rb:87:in `open'
	from /build/manageiq-appliance-build/scripts/uploader.rb:87:in `upload'
	from /build/manageiq-appliance-build/scripts/uploader.rb:48:in `block (2 levels) in run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:48:in `each'
	from /build/manageiq-appliance-build/scripts/uploader.rb:48:in `block in run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:31:in `each'
	from /build/manageiq-appliance-build/scripts/uploader.rb:31:in `run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:15:in `upload'
	from /build/manageiq-appliance-build/scripts/vmbuild.rb:223:in `<main>'
<internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- aws-sdk-s3 (LoadError)
	from <internal:/usr/share/rubygems/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /build/manageiq-appliance-build/scripts/uploader.rb:117:in `client'
	from /build/manageiq-appliance-build/scripts/uploader.rb:88:in `block in upload'
	from /build/manageiq-appliance-build/scripts/uploader.rb:87:in `open'
	from /build/manageiq-appliance-build/scripts/uploader.rb:87:in `upload'
	from /build/manageiq-appliance-build/scripts/uploader.rb:48:in `block (2 levels) in run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:48:in `each'
	from /build/manageiq-appliance-build/scripts/uploader.rb:48:in `block in run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:31:in `each'
	from /build/manageiq-appliance-build/scripts/uploader.rb:31:in `run'
	from /build/manageiq-appliance-build/scripts/uploader.rb:15:in `upload'
	from /build/manageiq-appliance-build/scripts/vmbuild.rb:223:in `<main>'
I, [2023-05-19T01:11:03.651303 #4113]  INFO -- :   adding: manageiq-azure-master-202305181547.vhd (deflated 98%)