### PR TITLE
Nightly build script changes to integrate with GHA

### DIFF
--- a/.github/workflows/build_appliances.yaml
+++ b/.github/workflows/build_appliances.yaml
@@ -1,0 +1,20 @@
+name: Build Appliances
+on:
+  repository_dispatch:
+    types:
+    - build
+  workflow_dispatch:
+jobs:
+  setup:
+    runs-on: self-hosted
+    steps:
+    - name: Clone Imagefactory
+      run: |
+        git clone https://www.github.com/bdunne/imagefactory.git /build/gha/$GITHUB_RUN_ID/imagefactory
+  build_appliances:
+    runs-on: self-hosted
+    needs: setup
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build appliance images
+      run: "bin/nightly-build.sh"

--- a/bin/nightly-build.sh
+++ b/bin/nightly-build.sh
@@ -16,23 +16,13 @@ mkdir -p ${LOG_DIR}
 BRANCH=master
 DATE_STAMP=`date +"%Y%m%d_%T"`
 LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}.log"
-CONTAINER_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_container.log"
-RPM_LOG_FILE="${LOG_DIR}/${BRANCH}_${DATE_STAMP}_rpm.log"
 BUILD_OPTIONS="--type nightly --upload --reference ${BRANCH} --copy-dir ${BRANCH}"
 
 if [ "${!#}" = "--fg" ]
 then
-  echo "Nightly RPM build kicked off, Log being saved in ${RPM_LOG_FILE} ..."
-  ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH 2>&1 |tee ${RPM_LOG_FILE}
-  [ ${PIPESTATUS[0]} -ne 0 ] && exit 1
-
   echo "Nightly Build kicked off, Log being saved in ${LOG_FILE} ..."
   time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS ${@:1:$#-1} 2>&1 | tee ${LOG_FILE}
-  time ${BUILD_DIR}/bin/container-build.sh -t nightly -r ${BRANCH} 2>&1 | tee ${CONTAINER_LOG_FILE}
 else
-  ( nohup time ${BUILD_DIR}/bin/rpm-build.sh -t nightly -r $BRANCH > ${RPM_LOG_FILE} 2>&1 &&
-    ( nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS $@ >${LOG_FILE} 2>&1 &
-      nohup time ${BUILD_DIR}/bin/container-build.sh -t nightly -r ${BRANCH} >${CONTAINER_LOG_FILE} 2>&1 ) ) &
-
+  nohup time ruby ${BUILD_DIR}/scripts/vmbuild.rb $BUILD_OPTIONS $@ >${LOG_FILE} 2>&1 &
   echo "Nightly Build kicked off, Logs @ ${LOG_DIR}/${BRANCH}_${DATE_STAMP}*.log..."
 fi


### PR DESCRIPTION
Remove RPM build and Container build from nightly-build.sh
- RPM and container builds are handled by github actions now.

Trigger nightly builds from Github Actions
- This will just start the appliance build. Building all platforms would exceed the job timeout.  That's for a future PR.
- Use my fork of imagefactory since the official one seems unmaintained and I have a few changes to work on python 3.9
- Use self-hosted to run on our build VM since we can't build appliances in GHA

