### PR TITLE
Fix issue when newer json gem is not present

### DIFF
--- a/scripts/vmbuild.rb
+++ b/scripts/vmbuild.rb
@@ -53,7 +53,7 @@ FileUtils.mkdir_p(STORAGE_DIR)
 # Set Storage directory in imagefactory config
 imagefactory_config = CFG_DIR.join("imagefactory.conf")
 require 'json'
-json = JSON.load_file(imagefactory_config)
+json = JSON.load(imagefactory_config.read)
 json["image_manager_args"]["storage_path"] = STORAGE_DIR
 File.write(imagefactory_config, json.to_json)
 


### PR DESCRIPTION
The JSON.load_file method is not present is the version of the JSON gem that comes with Ruby 2.7.

@jrafanie Please review
cc @bdunne 