### PR TITLE
Fully qualify the docker image

### DIFF
--- a/bin/rpm-build.sh
+++ b/bin/rpm-build.sh
@@ -4,7 +4,7 @@ set -ex
 BUILD_DIR="$(dirname "$(readlink -f "$0")")/.."
 
 CONFIG_OPTION=${CONFIG_OPTION:-$BUILD_DIR/OPTIONS}
-RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"manageiq/rpm_build"}
+RPM_BUILD_IMAGE=${RPM_BUILD_IMAGE:-"docker.io/manageiq/rpm_build"}
 RPM_CACHE_DIR=${RPM_CACHE_DIR:-$BUILD_DIR/rpm_cache}
 
 while getopts "t:r:h" opt; do


### PR DESCRIPTION
`Error: short-name resolution enforced but cannot prompt without a TTY`