### PR TITLE
Use el8/9 epel qpid proton 0.37.0+

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -2,7 +2,7 @@
 repo --name=baseos     --baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
 repo --name=appstream  --baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 repo --name=extras     --baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
-repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
+repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64
 
 repo --name=manageiq-18-radjabov         --baseurl=https://rpm.manageiq.org/release/18-radjabov/el$releasever/$basearch
 repo --name=manageiq-18-radjabov-noarch  --baseurl=https://rpm.manageiq.org/release/18-radjabov/el$releasever/noarch

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -2,7 +2,6 @@
 # dnf update uses these repos to update and reinstall packages.
 # Please also add to "build time repos" main/repos partial
 
-dnf config-manager --setopt=epel.exclude=*qpid-proton* --save
 <% if @build_type != "release" %>
 dnf config-manager --enable manageiq-*-nightly
 <% end %>


### PR DESCRIPTION
Undo https://github.com/ManageIQ/manageiq-appliance-build/pull/409 now that we're ready to use the upstream packages in el8 or el9 epel qpid proton 0.37.0+

To be merged with https://github.com/ManageIQ/manageiq/pull/22271
Needed for https://github.com/ManageIQ/manageiq/issues/22696

Followup: https://github.com/ManageIQ/manageiq-appliance-build/issues/560