### PR TITLE
[MORPHY] Lock down bundler to 2.4.x

### DIFF
--- a/kickstarts/centos8_build_machine.ks
+++ b/kickstarts/centos8_build_machine.ks
@@ -76,7 +76,7 @@ pushd /build/imagefactory/scripts
 popd
 
 pushd /build/manageiq-appliance-build/scripts
-  gem install bundler
+  gem install bundler -v '< 2.5'
   export PATH="/usr/local/bin:${PATH}"
   bundle install
 popd


### PR DESCRIPTION
bundler 2.5 dropped support for Ruby 2.x, so since morphy runs on 2.6, we need to lock down to bundler 2.4.x.

Similar to https://github.com/ManageIQ/manageiq/pull/22820

@agrare Please review
cc @bdunne @jrafanie