### PR TITLE
[morphy] CentOS Stream 8 is EOL

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -1,7 +1,7 @@
 # build time repos - these repos are used to install the initial packages
-repo --name=baseos     --baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/
-repo --name=appstream  --baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
-repo --name=extras     --baseurl=http://mirror.centos.org/centos/8-stream/extras/x86_64/os/
+repo --name=baseos     --baseurl=http://vault.centos.org/centos/8-stream/BaseOS/x86_64/os/
+repo --name=appstream  --baseurl=http://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
+repo --name=extras     --baseurl=http://vault.centos.org/centos/8-stream/extras/x86_64/os/
 repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
 repo --name=ovirt-4.4  --mirrorlist=https://resources.ovirt.org/pub/yum-repo/mirrorlist-ovirt-4.4-el$releasever
 


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq-rpm_build/pull/467

Unfortunately the repos RPM in the vault still points to mirrors.centos.org which is no longer serving Stream 8.  I patched the RPMs and posted them on rpm.manageiq.org with a change to point all repos to the vault.