### PR TITLE
Stop using legacy network interface names (eth0)

### DIFF
--- a/kickstarts/base.ks.erb
+++ b/kickstarts/base.ks.erb
@@ -127,23 +127,8 @@ passwd -e root
 # Remove root from the cockpit disallowed-users list
 sed -i s/root//g /etc/cockpit/disallowed-users
 
-# During the image build, dracut sets up ifcfg-en<whatever> for the device.
-# On the appliances we expect eth0, so remove all the ifcfg-en<whatever> device configurations
-# and write a config for eth0 allowing the 'network' service to come up cleanly.
-rm -f /etc/sysconfig/network-scripts/ifcfg-en*
-
 # Remove machine-id
 cat /dev/null > /etc/machine-id
-
-cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
-DEVICE=eth0
-BOOTPROTO=dhcp
-ONBOOT=yes
-TYPE=Ethernet
-USERCTL=no
-NM_CONTROLLED=no
-DEFROUTE=yes
-EOF
 
 chvt 1
 ) 2>&1 | tee /dev/tty3

--- a/kickstarts/partials/main/bootloader.ks.erb
+++ b/kickstarts/partials/main/bootloader.ks.erb
@@ -1,9 +1,9 @@
 <% if @target == "ec2" || @target == "openstack" %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=tty0 console=ttyS0,115200n8"
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet console=tty0 console=ttyS0,115200n8"
 <% elsif @target == "azure" %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet console=ttyS0 earlyprintk=ttyS0 rootdelay=300"
 <% elsif @target == "gce" %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0,38400n8"
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet console=ttyS0,38400n8"
 <% else %>
-bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet net.ifnames=0 biosdevname=0 console=ttyS0,115200 console=tty0"
+bootloader --location=mbr --driveorder=vda --append="crashkernel=auto rhgb quiet console=ttyS0,115200 console=tty0"
 <% end %>

--- a/kickstarts/partials/post/gce.ks.erb
+++ b/kickstarts/partials/post/gce.ks.erb
@@ -28,5 +28,3 @@ EOF
 
 # Lock root account
 usermod -L root
-
-echo "PERSISTENT_DHCLIENT=1" >> /etc/sysconfig/network-scripts/ifcfg-eth0


### PR DESCRIPTION
It's no longer working for GCE and Azure appliances, they mark the connection as `unmanaged` and won't allow it to come up.  Also, our scripts no longer depend on the interface name in EL9.

net.ifnames=0 reverts to legacy adapter names (eth0)
biosdevname does the same for Dell systems and requires a package we don't have installed
network-scripts are no longer used by NetworkManager
