### PR TITLE
GCE appliances require google-guest-agent

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -24,6 +24,8 @@ hyperv-daemons
 qemu-guest-agent
 <% when "vsphere" %>
 open-vm-tools
+<% when "gce" %>
+google-guest-agent
 <% end %>
 
 <%= render_partial_if_exist "packages/includes-extra" %>


### PR DESCRIPTION
Without this, gcloud compute ssh connections won't work and you can't get into the appliance

Related to #573