### PR TITLE
[quinteros]  Update CentOS Stream 8 repos

### DIFF
--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -1,6 +1,9 @@
 <%= @product_name %>-appliance
 <%= @product_name %>-appliance-tools
 
+https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm
+https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm
+
 epel-release
 manageiq-release
 


### PR DESCRIPTION
EL8 Mirrors and mirror list are no longer available.  Point to the vault instead.

This is not used for the installation itself, but for appliance use after install.  Without these packages, all dnf commands will fail to fetch the repo metadata.