### PR TITLE
[quinteros] Lock down to ruby 3.0.4 from Appstream

### DIFF
--- a/kickstarts/partials/main/repos.ks.erb
+++ b/kickstarts/partials/main/repos.ks.erb
@@ -3,9 +3,6 @@ repo --name=baseos     --baseurl=https://vault.centos.org/centos/8-stream/BaseOS
 repo --name=appstream  --baseurl=https://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
 repo --name=extras     --baseurl=https://vault.centos.org/centos/8-stream/extras/x86_64/os/
 repo --name=epel       --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=x86_64 --excludepkgs=*qpid-proton*
-repo --name=ubi-8-baseos-rpms --baseurl https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os --excludepkgs=rpm*
-repo --name=ubi-8-appstream-rpms --baseurl https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os --excludepkgs=rpm*
-repo --name=ubi-8-codeready-builder-rpms --baseurl https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os --excludepkgs=rpm*
 
 repo --name=manageiq-17-quinteros         --baseurl=https://rpm.manageiq.org/release/17-quinteros/el$releasever/$basearch
 repo --name=manageiq-17-quinteros-noarch  --baseurl=https://rpm.manageiq.org/release/17-quinteros/el$releasever/noarch

--- a/kickstarts/partials/packages/includes.ks.erb
+++ b/kickstarts/partials/packages/includes.ks.erb
@@ -1,9 +1,6 @@
 <%= @product_name %>-appliance
 <%= @product_name %>-appliance-tools
 
-https://rpm.manageiq.org/builds/centos/centos-gpg-keys-8-6.1.el8.noarch.rpm
-https://rpm.manageiq.org/builds/centos/centos-stream-repos-8-6.1.el8.noarch.rpm
-
 epel-release
 manageiq-release
 

--- a/kickstarts/partials/post/repos.ks.erb
+++ b/kickstarts/partials/post/repos.ks.erb
@@ -2,6 +2,9 @@
 # dnf update uses these repos to update and reinstall packages.
 # Please also add to "build time repos" main/repos partial
 
+sed -i 's/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS-*.repo
+sed -i 's/#baseurl=http:\/\/mirror/baseurl=http:\/\/vault/g' /etc/yum.repos.d/CentOS-*.repo
+
 dnf config-manager --setopt=epel.exclude=*qpid-proton* --save
 <% if @build_type != "release" %>
 dnf config-manager --enable manageiq-*-nightly


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-rpm_build/pull/521