### PR TITLE
Use appliance console cli for configuring single appliance or primary/standby databases

### DIFF
--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -959,25 +959,6 @@ setup_vm_resources() {
 }
 
 
-# Function to configure MIQ appliance
-# Parameters:
-#   $1: replication_type - "none", "primary", or "standby"
-#   $2: cluster_node_number - node number (1 for primary, 2 for standby)
-#   $3: primary_host_ip - IP address of primary host (required for standby)
-#   $4: standby_host_ip - IP address of standby host (required for standby)
-appliance_configure() {
-    local replication_type=${1:-"none"}
-    local cluster_node_number=${2:-""}
-    local primary_host_ip=${3:-""}
-    local standby_host_ip=${4:-""}
-
-    log "Starting appliance configuration for VM: $VM_NAME..."
-
-    configure_appliance "$replication_type" "$cluster_node_number" "$primary_host_ip" "$standby_host_ip" || exit 1
-    check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
-
-    log "Appliance configuration completed successfully for VM: $VM_NAME."
-}
 
 # Verify prereq and setup variables used in the script
 verify_prereq
@@ -1003,11 +984,12 @@ primary_vmi_ip=$vmi_ip
 
 # Deploy second VM if HA mode
 if [[ "$HA" == "true" ]]; then
-    # Now configure primary (no standby IP needed for primary)
+    # Configure primary
     log "=== Configuring PRIMARY VM ==="
     vmi_name=$primary_vmi_name
     vmi_ip=$primary_vmi_ip
-    appliance_configure "primary" "1" "" ""
+    configure_appliance "primary" "1" "" "" || exit 1
+    check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
     log "Primary VM configuration completed successfully."
 
     log "=== Deploying STANDBY VM ==="
@@ -1017,11 +999,12 @@ if [[ "$HA" == "true" ]]; then
     standby_vmi_ip=$vmi_ip
     log "Standby VM setup completed successfully."
 
-    # Configure standby with primary IP
+    # Configure standby
     log "=== Configuring STANDBY VM ==="
     vmi_name=$standby_vmi_name
     vmi_ip=$standby_vmi_ip
-    appliance_configure "standby" "2" "$primary_vmi_ip" "$standby_vmi_ip"
+    configure_appliance "standby" "2" "$primary_vmi_ip" "$standby_vmi_ip" || exit 1
+    # ideally, standby shouldn't start evmserverd so we don't need to check it
     log "Standby VM configuration completed successfully."
 
     log "=== HA Deployment Complete ==="
@@ -1030,7 +1013,8 @@ if [[ "$HA" == "true" ]]; then
     log "Standby VM login: virtctl ssh root@vmi/$standby_vmi_name -n $NAMESPACE"
 else
     # Standard single VM deployment
-    appliance_configure "none" "" "" ""
+    configure_appliance "none" "" "" "" || exit 1
+    check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
     log "Standard deployment completed successfully."
     log "Full configuration log can be found at $LOG_FILE"
     log "To login: virtctl ssh root@vmi/$vmi_name -n $NAMESPACE"

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -798,12 +798,10 @@ configure_appliance() {
 
     local cli_cmd="cd /var/www/miq/vmdb && bundle exec appliance_console_cli --region=55 --dbname=vmdb_production --username=root --password=smartvm --dbdisk=auto"
 
-    # Standbys will be initialized as standby dbs, fetch their key from the primary and will not have a messaging server setup
     if [[ "$replication_type" != "standby" ]]; then
         cli_cmd="$cli_cmd --internal --server start --key --message-server-config --message-server-host=${vmi_ip}.local --message-keystore-username=admin --message-keystore-password=smartvm"
     fi
 
-    # Add replication parameters or standalone based on HA being enabled
     if [[ "$replication_type" == "primary" ]]; then
         log "Configuring as PRIMARY node (cluster node: $cluster_node_number)"
         cli_cmd="$cli_cmd --replication=primary --cluster-node-number=$cluster_node_number"
@@ -849,7 +847,6 @@ REMOTE_CMD
                 exp_continue
             }
             eof {
-                # Command completed, check exit status
                 catch wait result
                 set exit_status [lindex \$result 3]
                 exit \$exit_status
@@ -867,7 +864,6 @@ EOF
     local elapsed=0
     local sleep_interval=5
 
-    # Wait for expect process with timeout
     while kill -0 $expect_pid 2>/dev/null; do
         if [ $elapsed -ge $timeout_seconds ]; then
             log_error "Configuration timed out after 10 minutes"
@@ -883,11 +879,9 @@ EOF
         elapsed=$((elapsed + sleep_interval))
     done
 
-    # Get exit status and output
     wait $expect_pid
     configure_status=$?
 
-    # Log all output
     local cleaned_output=$(cat "$temp_output" | strip_cr_from_expect_output)
     echo "$cleaned_output" >> $LOG_FILE
     cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
@@ -987,15 +981,12 @@ setup_vm_resources() {
 
 
 
-# Verify prereq and setup variables used in the script
 verify_prereq
 env_setup
 verify_env_prereq
 
-# Execute the appliance_configure (Main Function) and handle its exit status
 log "Starting MIQ Appliance Configuration Script..."
 
-# Deploy first VM (primary if HA, single if not)
 if [[ "$HA" == "true" ]]; then
     log "HA mode enabled - deploying primary VM..."
     set_vm_variables "primary"
@@ -1011,7 +1002,6 @@ if [[ "$HA" == "true" ]]; then
     PRIMARY_VMI_NAME=$vmi_name
     PRIMARY_IP=$vmi_ip
 
-    # Configure primary (uses current vmi_name and vmi_ip globals)
     log "=== Configuring PRIMARY VM ==="
     configure_appliance "primary" "1" "" "" || exit 1
     check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
@@ -1024,18 +1014,15 @@ if [[ "$HA" == "true" ]]; then
     STANDBY_IP=$vmi_ip
     log "Standby VM setup completed successfully."
 
-    # Configure standby (uses current vmi_name and vmi_ip globals)
     log "=== Configuring STANDBY VM ==="
     configure_appliance "standby" "2" "$PRIMARY_IP" "$STANDBY_IP" || exit 1
-    # ideally, standby shouldn't start evmserverd so we don't need to check it
-    log "Standby VM configuration completed successfully."
+    log "Standby VM configuration completed successfully (evmserverd check skipped for standby)."
 
     log "=== HA Deployment Complete ==="
     log "Full configuration log can be found at $LOG_FILE"
     log "Primary VM login: virtctl ssh root@vmi/$PRIMARY_VMI_NAME -n $NAMESPACE"
     log "Standby VM login: virtctl ssh root@vmi/$STANDBY_VMI_NAME -n $NAMESPACE"
 else
-    # Standard single VM deployment
     configure_appliance "none" "" "" "" || exit 1
     check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
     log "Standard deployment completed successfully."

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -1005,16 +1005,14 @@ fi
 
 setup_vm_resources
 
-# Store primary VM info for HA configuration
-primary_vmi_name=$vmi_name
-primary_vmi_ip=$vmi_ip
-
 # Deploy second VM if HA mode
 if [[ "$HA" == "true" ]]; then
-    # Configure primary
+    # Store primary VM info for HA configuration (vmi_name and vmi_ip are set by setup_vm_resources)
+    PRIMARY_VMI_NAME=$vmi_name
+    PRIMARY_IP=$vmi_ip
+
+    # Configure primary (uses current vmi_name and vmi_ip globals)
     log "=== Configuring PRIMARY VM ==="
-    vmi_name=$primary_vmi_name
-    vmi_ip=$primary_vmi_ip
     configure_appliance "primary" "1" "" "" || exit 1
     check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
     log "Primary VM configuration completed successfully."
@@ -1022,22 +1020,20 @@ if [[ "$HA" == "true" ]]; then
     log "=== Deploying STANDBY VM ==="
     set_vm_variables "standby"
     setup_vm_resources
-    standby_vmi_name=$vmi_name
-    standby_vmi_ip=$vmi_ip
+    STANDBY_VMI_NAME=$vmi_name
+    STANDBY_IP=$vmi_ip
     log "Standby VM setup completed successfully."
 
-    # Configure standby
+    # Configure standby (uses current vmi_name and vmi_ip globals)
     log "=== Configuring STANDBY VM ==="
-    vmi_name=$standby_vmi_name
-    vmi_ip=$standby_vmi_ip
-    configure_appliance "standby" "2" "$primary_vmi_ip" "$standby_vmi_ip" || exit 1
+    configure_appliance "standby" "2" "$PRIMARY_IP" "$STANDBY_IP" || exit 1
     # ideally, standby shouldn't start evmserverd so we don't need to check it
     log "Standby VM configuration completed successfully."
 
     log "=== HA Deployment Complete ==="
     log "Full configuration log can be found at $LOG_FILE"
-    log "Primary VM login: virtctl ssh root@vmi/$primary_vmi_name -n $NAMESPACE"
-    log "Standby VM login: virtctl ssh root@vmi/$standby_vmi_name -n $NAMESPACE"
+    log "Primary VM login: virtctl ssh root@vmi/$PRIMARY_VMI_NAME -n $NAMESPACE"
+    log "Standby VM login: virtctl ssh root@vmi/$STANDBY_VMI_NAME -n $NAMESPACE"
 else
     # Standard single VM deployment
     configure_appliance "none" "" "" "" || exit 1

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -812,22 +812,31 @@ configure_appliance() {
         cli_cmd="$cli_cmd --fetch-key=$primary_host_ip --sshlogin=root --sshpassword=$NEWPASSWORD --replication=standby --cluster-node-number=$cluster_node_number --primary-host=$primary_host_ip --standby-host=$standby_host_ip"
     fi
 
-    # Redirect stderr to stdout in the remote command for complete output capture
-    cli_cmd="$cli_cmd 2>&1"
-
-    # Create a temporary file for output
     local temp_output=$(mktemp)
     local temp_stderr=$(mktemp)
+
+    # Build the remote command with proper exit status capture
+    # Use a here-document to avoid complex escaping
+    local remote_cmd=$(cat <<'REMOTE_CMD'
+%CLI_CMD% 2>&1
+EXIT_CODE=$?
+echo "EXIT_STATUS=$EXIT_CODE"
+exit $EXIT_CODE
+REMOTE_CMD
+)
+    # Substitute the actual CLI command
+    remote_cmd="${remote_cmd//%CLI_CMD%/$cli_cmd}"
 
     log "Full CLI command to execute:"
     log "$cli_cmd"
     log "Running appliance_console_cli..."
+
     (expect <<EOF
         set timeout 600
         log_user 1
         exp_internal 0
 
-        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE -c "$cli_cmd"
+        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE -c {$remote_cmd}
 
         match_max 32000
         expect {
@@ -879,12 +888,27 @@ EOF
     configure_status=$?
 
     # Log all output
-    cat "$temp_output" | strip_cr_from_expect_output >> $LOG_FILE
+    local cleaned_output=$(cat "$temp_output" | strip_cr_from_expect_output)
+    echo "$cleaned_output" >> $LOG_FILE
     cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
+
+    # Extract the actual exit status from the remote command
+    local remote_exit_status=$(echo "$cleaned_output" | grep "EXIT_STATUS=" | tail -1 | cut -d= -f2)
+
     rm -f "$temp_output" "$temp_stderr"
 
     if [ $configure_status -ne 0 ]; then
-        log_error "Appliance Configuration failed with exit code: $configure_status"
+        log_error "Appliance Configuration failed - SSH/expect error with exit code: $configure_status"
+        return 1
+    fi
+
+    if [ -n "$remote_exit_status" ] && [ "$remote_exit_status" -ne 0 ]; then
+        log_error "Appliance Configuration failed - appliance_console_cli returned exit code: $remote_exit_status"
+        return 1
+    fi
+
+    if [ -z "$remote_exit_status" ]; then
+        log_error "Appliance Configuration failed - could not determine exit status of appliance_console_cli"
         return 1
     fi
 
@@ -909,8 +933,8 @@ check_evmserverd() {
         send "$NEWPASSWORD\r"
         expect "#"
         send "systemctl is-active evmserverd\r"
-        expect -re "(active|inactive)"
-        set status \$expect_out(0,string)
+        expect -re "(inactive|active)"
+        set status \$expect_out(1,string)
         send "exit\r"
         expect eof
         puts \$status
@@ -919,12 +943,15 @@ EOF
 
         echo "$evmserverd_output" >> $LOG_FILE
 
-        if echo "$evmserverd_output" | grep -q "active"; then
+        # Check if inactive first (error condition)
+        if echo "$evmserverd_output" | grep -qw "inactive"; then
+            log "evmserverd is inactive (attempt $attempt of $max_attempts)"
+        elif echo "$evmserverd_output" | grep -qw "active"; then
             log "evmserverd is active!"
             return 0
+        else
+            log "evmserverd status unknown (attempt $attempt of $max_attempts)"
         fi
-
-        log "evmserverd not yet active (attempt $attempt of $max_attempts)"
 
         if [ $attempt -lt $max_attempts ]; then
             sleep 30

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -760,21 +760,12 @@ EOF
     return 0
 }
 
-# Function to configure the appliance
-configure_appliance() {
-
-    log "Configuring the appliance on VM $vmi_name..."
-
-    # Use background process with timeout for portability (works on macOS and Linux)
-    # Create a temporary file for output
-    local temp_output=$(mktemp)
-
-    # Run expect in background and capture its PID
-    (expect <<EOF
-        set timeout -1
-        log_user 1
-        exp_internal 0
-        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE
+# Function to set hostname and update /etc/hosts on the VM
+set_hostname() {
+    log "Setting hostname and updating /etc/hosts..."
+    local setup_output=$(expect <<EOF 2>&1
+        set timeout 60
+        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE -c "hostnamectl set-hostname ${vmi_ip}.local && echo '${vmi_ip} ${vmi_ip}.local 192' >> /etc/hosts"
         match_max 32000
         expect {
             -re "Are you sure you want to continue connecting.*\\?" {
@@ -785,40 +776,57 @@ configure_appliance() {
                 send "$NEWPASSWORD\r"
                 exp_continue
             }
-            "#" {
-                send "hostnamectl set-hostname ${vmi_ip}.local\r"
-                send "echo '${vmi_ip} ${vmi_ip}.local 192' >> /etc/hosts\r"
-                send "appliance_console_cli --region=55 --internal --dbname=vmdb_production --username=root --password=smartvm --dbdisk=auto --key --message-server-config --message-server-host=${vmi_ip}.local --message-keystore-username=admin --message-keystore-password=smartvm > /tmp/appliance_console_cli.log 2>&1; echo \"EXIT_CODE:\$?\"\r"
-                expect {
-                    -re "EXIT_CODE:0" {
-                        puts "appliance_console_cli completed successfully"
-                    }
-                    -re "EXIT_CODE:(\[0-9\]+)" {
-                        puts "ERROR: appliance_console_cli failed with exit code \$expect_out(1,string)"
-                        puts "Check /tmp/appliance_console_cli.log for details"
-                        send "cat /tmp/appliance_console_cli.log\r"
-                        expect -re "#|\\$"
-                        send "exit\r"
-                        expect eof
-                        exit 1
-                    }
-                    timeout {
-                        puts "ERROR: appliance_console_cli timed out"
-                        puts "Check /tmp/appliance_console_cli.log for details"
-                        send "cat /tmp/appliance_console_cli.log\r"
-                        expect -re "#|\\$"
-                        send "exit\r"
-                        expect eof
-                        exit 1
-                    }
-                }
-                expect -re "#|\\$"
-                send "exit\r"
-                expect eof
+            eof
+        }
+EOF
+    )
+    echo "$setup_output" | strip_cr_from_expect_output >> $LOG_FILE
+}
+
+# Function to configure the appliance
+configure_appliance() {
+
+    log "Configuring the appliance on VM $vmi_name..."
+
+    # Set hostname and update /etc/hosts
+    set_hostname
+
+    # Create a temporary file for output
+    local temp_output=$(mktemp)
+    local temp_stderr=$(mktemp)
+
+    # Run appliance_console_cli via SSH command with expect handling authentication
+    log "Running appliance_console_cli..."
+    (expect <<EOF
+        set timeout 600
+        log_user 1
+        exp_internal 0
+
+        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE -c "cd /var/www/miq/vmdb && bundle exec appliance_console_cli --region=55 --internal --dbname=vmdb_production --username=root --password=smartvm --dbdisk=auto --key --message-server-config --message-server-host=${vmi_ip}.local --message-keystore-username=admin --message-keystore-password=smartvm 2>&1"
+
+        match_max 32000
+        expect {
+            -re "Are you sure you want to continue connecting.*\\?" {
+                send "yes\r"
+                exp_continue
+            }
+            "root@vmi.${vmi_name}.${NAMESPACE}'s password: " {
+                send "$NEWPASSWORD\r"
+                exp_continue
+            }
+            eof {
+                # Command completed, check exit status
+                catch wait result
+                set exit_status [lindex \$result 3]
+                exit \$exit_status
+            }
+            timeout {
+                puts "ERROR: appliance_console_cli timed out after 10 minutes"
+                exit 1
             }
         }
 EOF
-    ) > "$temp_output" 2>&1 &
+    ) > "$temp_output" 2> "$temp_stderr" &
 
     local expect_pid=$!
     local timeout_seconds=600
@@ -832,10 +840,9 @@ EOF
             kill -TERM $expect_pid 2>/dev/null
             sleep 2
             kill -KILL $expect_pid 2>/dev/null
-            configure_output=$(cat "$temp_output")
-            rm -f "$temp_output"
-            log_error "Configuration timed out after 10 minutes. Last captured output:
-$(echo "$configure_output" | strip_cr_from_expect_output)"
+            cat "$temp_output" | strip_cr_from_expect_output >> $LOG_FILE
+            cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
+            rm -f "$temp_output" "$temp_stderr"
             return 1
         fi
         sleep $sleep_interval
@@ -845,15 +852,15 @@ $(echo "$configure_output" | strip_cr_from_expect_output)"
     # Get exit status and output
     wait $expect_pid
     configure_status=$?
-    configure_output=$(cat "$temp_output")
-    rm -f "$temp_output"
 
-    echo "$configure_output" | strip_cr_from_expect_output >> $LOG_FILE
+    # Log all output
+    cat "$temp_output" | strip_cr_from_expect_output >> $LOG_FILE
+    cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
+    rm -f "$temp_output" "$temp_stderr"
 
     # Check if appliance is configured
     if [ $configure_status -ne 0 ]; then
-        log_error "Appliance Configuration failed. Output:
-$(echo "$configure_output" | strip_cr_from_expect_output)"
+        log_error "Appliance Configuration failed with exit code: $configure_status"
         return 1
     fi
 
@@ -932,7 +939,7 @@ setup_vm_resources() {
 appliance_configure() {
     log "Starting appliance configuration for VM: $VM_NAME..."
 
-    configure_appliance || { log_error "configure_appliance failed"; exit 1; }
+    configure_appliance || exit 1
     check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
 
     log "Appliance configuration completed successfully for VM: $VM_NAME."

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -672,9 +672,6 @@ ssh_into_vm() {
         return 1
     fi
 
-    log "SSH is ready, waiting 30 seconds for VM to fully initialize..."
-    sleep 30
-
     log "SSH into the VM $vmi_name to change password..."
     ssh_output=$(expect <<EOF 2>&1
         set timeout 60

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -909,13 +909,13 @@ EOF
 
 # Function to check evmserverd status with polling
 check_evmserverd() {
-    log "Waiting for evmserverd to become active (checking every 30 seconds for up to 10 minutes)..."
+    log "Checking evmserverd status..."
 
     local max_attempts=20
     local attempt=1
 
     while [ $attempt -le $max_attempts ]; do
-        log "Checking evmserverd status (attempt $attempt of $max_attempts)..."
+        log "  Checking evmserverd status (attempt $attempt of $max_attempts)..."
 
         evmserverd_output=$(expect <<EOF 2>&1
         set timeout 30
@@ -936,12 +936,12 @@ EOF
 
         # Check if inactive first (error condition)
         if echo "$evmserverd_output" | grep -qw "inactive"; then
-            log "evmserverd is inactive (attempt $attempt of $max_attempts)"
+            log "  evmserverd is inactive (attempt $attempt of $max_attempts)"
         elif echo "$evmserverd_output" | grep -qw "active"; then
-            log "evmserverd is active!"
+            log "Checking evmserverd status...completed successfully."
             return 0
         else
-            log "evmserverd status unknown (attempt $attempt of $max_attempts)"
+            log "  evmserverd status unknown (attempt $attempt of $max_attempts)"
         fi
 
         if [ $attempt -lt $max_attempts ]; then
@@ -974,6 +974,8 @@ setup_vm_resources() {
 
     # Reset the initial ssh password
     ssh_into_vm || { log_error "ssh_into_vm failed"; exit 1; }
+
+    log "Setting up VM resources...completed successfully."
 }
 
 

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -811,7 +811,6 @@ configure_appliance() {
     fi
 
     local temp_output=$(mktemp)
-    local temp_stderr=$(mktemp)
 
     # Build the remote command with proper exit status capture
     # Use a here-document to avoid complex escaping
@@ -857,7 +856,7 @@ REMOTE_CMD
             }
         }
 EOF
-    ) > "$temp_output" 2> "$temp_stderr" &
+    ) > "$temp_output" 2>&1 &
 
     local expect_pid=$!
     local timeout_seconds=600
@@ -871,8 +870,7 @@ EOF
             sleep 2
             kill -KILL $expect_pid 2>/dev/null
             cat "$temp_output" | strip_cr_from_expect_output >> $LOG_FILE
-            cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
-            rm -f "$temp_output" "$temp_stderr"
+            rm -f "$temp_output"
             return 1
         fi
         sleep $sleep_interval
@@ -884,12 +882,11 @@ EOF
 
     local cleaned_output=$(cat "$temp_output" | strip_cr_from_expect_output)
     echo "$cleaned_output" >> $LOG_FILE
-    cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
 
     # Extract the actual exit status from the remote command
     local remote_exit_status=$(echo "$cleaned_output" | grep "EXIT_STATUS=" | tail -1 | cut -d= -f2)
 
-    rm -f "$temp_output" "$temp_stderr"
+    rm -f "$temp_output"
 
     if [ $configure_status -ne 0 ]; then
         log_error "Appliance Configuration failed - SSH/expect error with exit code: $configure_status"

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -788,75 +788,30 @@ configure_appliance() {
             "#" {
                 send "hostnamectl set-hostname ${vmi_ip}.local\r"
                 send "echo '${vmi_ip} ${vmi_ip}.local 192' >> /etc/hosts\r"
-                send "appliance_console\r"
-                expect "Press any key to continue.\r"
-                send " "
-
-                expect -re "Choose the advanced setting: "
-                # Capture the menu to find the Configure Application option number
-                set menu_buffer \$expect_out(buffer)
-
-                # Look for the Configure Application option (format: "4) Configure Application")
-                if {[regexp {([0-9]+)\) Configure Application} \$menu_buffer match config_number]} {
-                    puts "Found Configure Application option at number: \$config_number"
-                    send "\$config_number\r"
-                } else {
-                    puts "ERROR: Could not find 'Configure Application' option in menu"
-                    puts "MENU CONTENT: \$menu_buffer"
-                    exit 1
+                send "appliance_console_cli --region=55 --internal --dbname=vmdb_production --username=root --password=smartvm --dbdisk=auto --key --message-server-config --message-server-host=${vmi_ip}.local --message-keystore-username=admin --message-keystore-password=smartvm > /tmp/appliance_console_cli.log 2>&1; echo \"EXIT_CODE:\$?\"\r"
+                expect {
+                    -re "EXIT_CODE:0" {
+                        puts "appliance_console_cli completed successfully"
+                    }
+                    -re "EXIT_CODE:(\[0-9\]+)" {
+                        puts "ERROR: appliance_console_cli failed with exit code \$expect_out(1,string)"
+                        puts "Check /tmp/appliance_console_cli.log for details"
+                        send "cat /tmp/appliance_console_cli.log\r"
+                        expect -re "#|\\$"
+                        send "exit\r"
+                        expect eof
+                        exit 1
+                    }
+                    timeout {
+                        puts "ERROR: appliance_console_cli timed out"
+                        puts "Check /tmp/appliance_console_cli.log for details"
+                        send "cat /tmp/appliance_console_cli.log\r"
+                        expect -re "#|\\$"
+                        send "exit\r"
+                        expect eof
+                        exit 1
+                    }
                 }
-
-                expect "Choose the encryption key: |1| "
-                send "1\r"
-                expect "Choose the database operation: "
-                send "1\r"
-                expect "Choose the configure messaging: "
-                send "1\r"
-                expect "Choose the database disk: |1| "
-                send "1\r"
-                expect "? (Y/N): |N| "
-                send "n\r"
-                expect "Enter the database region number: *"
-                send "55\r"
-                expect "Enter the database password on localhost: "
-                send "smartvm\r"
-                expect "Enter the database password on localhost: "
-                send "smartvm\r"
-                expect "Already configured on this Appliance, Un-Configure first? (Y/N): "
-                send "y\r"
-                expect "Proceed with Configuration? (Y/N): "
-                send "y\r"
-                expect "Enter the Message Server Hostname: |${vmi_ip}.local| "
-                send "\r"
-                expect "\[?2004l\rEnter the Message Keystore Username: |admin| \[?2004h"
-                send "\r"
-                expect "\[?2004l\rEnter the Message Keystore Password: "
-                send "smartvm\r"
-                expect "\[?2004l\rEnter the Message Keystore Password: "
-                send "smartvm\r"
-                expect "Configure a new persistent disk volume? (optional) (Y/N): "
-                send "n\r"
-                expect "Proceed? (Y/N): "
-                send "y\r"
-                expect "Press any key to continue.\r"
-                send " "
-                expect "Press any key to continue.\r"
-                send " "
-
-                expect -re "Choose the advanced setting: "
-                # Capture the menu to find the Quit option number
-                set menu_buffer \$expect_out(buffer)
-
-                # Look for the Quit option (format: "17) Quit")
-                if {[regexp {([0-9]+)\) Quit} \$menu_buffer match quit_number]} {
-                    puts "Found Quit option at number: \$quit_number"
-                    send "\$quit_number\r"
-                } else {
-                    puts "ERROR: Could not find 'Quit' option in menu"
-                    puts "MENU CONTENT: \$menu_buffer"
-                    exit 1
-                }
-
                 expect -re "#|\\$"
                 send "exit\r"
                 expect eof

--- a/bin/deploy_kubevirt_vm
+++ b/bin/deploy_kubevirt_vm
@@ -784,25 +784,53 @@ EOF
 }
 
 # Function to configure the appliance
+# Parameters:
+#   $1: replication_type - "none", "primary", or "standby"
+#   $2: cluster_node_number - node number (1 for primary, 2 for standby)
+#   $3: primary_host_ip - IP address of primary host (required for standby)
+#   $4: standby_host_ip - IP address of standby host (required for standby)
 configure_appliance() {
+    local replication_type=${1:-"none"}
+    local cluster_node_number=${2:-""}
+    local primary_host_ip=${3:-""}
+    local standby_host_ip=${4:-""}
 
-    log "Configuring the appliance on VM $vmi_name..."
+    log "Configuring the appliance on VM $vmi_name (replication: $replication_type)..."
 
-    # Set hostname and update /etc/hosts
     set_hostname
+
+    local cli_cmd="cd /var/www/miq/vmdb && bundle exec appliance_console_cli --region=55 --dbname=vmdb_production --username=root --password=smartvm --dbdisk=auto"
+
+    # Standbys will be initialized as standby dbs, fetch their key from the primary and will not have a messaging server setup
+    if [[ "$replication_type" != "standby" ]]; then
+        cli_cmd="$cli_cmd --internal --server start --key --message-server-config --message-server-host=${vmi_ip}.local --message-keystore-username=admin --message-keystore-password=smartvm"
+    fi
+
+    # Add replication parameters or standalone based on HA being enabled
+    if [[ "$replication_type" == "primary" ]]; then
+        log "Configuring as PRIMARY node (cluster node: $cluster_node_number)"
+        cli_cmd="$cli_cmd --replication=primary --cluster-node-number=$cluster_node_number"
+    elif [[ "$replication_type" == "standby" ]]; then
+        log "Configuring as STANDBY node (cluster node: $cluster_node_number, primary: $primary_host_ip, standby: $standby_host_ip)"
+        cli_cmd="$cli_cmd --fetch-key=$primary_host_ip --sshlogin=root --sshpassword=$NEWPASSWORD --replication=standby --cluster-node-number=$cluster_node_number --primary-host=$primary_host_ip --standby-host=$standby_host_ip"
+    fi
+
+    # Redirect stderr to stdout in the remote command for complete output capture
+    cli_cmd="$cli_cmd 2>&1"
 
     # Create a temporary file for output
     local temp_output=$(mktemp)
     local temp_stderr=$(mktemp)
 
-    # Run appliance_console_cli via SSH command with expect handling authentication
+    log "Full CLI command to execute:"
+    log "$cli_cmd"
     log "Running appliance_console_cli..."
     (expect <<EOF
         set timeout 600
         log_user 1
         exp_internal 0
 
-        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE -c "cd /var/www/miq/vmdb && bundle exec appliance_console_cli --region=55 --internal --dbname=vmdb_production --username=root --password=smartvm --dbdisk=auto --key --message-server-config --message-server-host=${vmi_ip}.local --message-keystore-username=admin --message-keystore-password=smartvm 2>&1"
+        spawn virtctl ssh root@vmi/$vmi_name -n $NAMESPACE -c "$cli_cmd"
 
         match_max 32000
         expect {
@@ -858,7 +886,6 @@ EOF
     cat "$temp_stderr" | strip_cr_from_expect_output >> $LOG_FILE
     rm -f "$temp_output" "$temp_stderr"
 
-    # Check if appliance is configured
     if [ $configure_status -ne 0 ]; then
         log_error "Appliance Configuration failed with exit code: $configure_status"
         return 1
@@ -936,10 +963,20 @@ setup_vm_resources() {
 
 
 # Function to configure MIQ appliance
+# Parameters:
+#   $1: replication_type - "none", "primary", or "standby"
+#   $2: cluster_node_number - node number (1 for primary, 2 for standby)
+#   $3: primary_host_ip - IP address of primary host (required for standby)
+#   $4: standby_host_ip - IP address of standby host (required for standby)
 appliance_configure() {
+    local replication_type=${1:-"none"}
+    local cluster_node_number=${2:-""}
+    local primary_host_ip=${3:-""}
+    local standby_host_ip=${4:-""}
+
     log "Starting appliance configuration for VM: $VM_NAME..."
 
-    configure_appliance || exit 1
+    configure_appliance "$replication_type" "$cluster_node_number" "$primary_host_ip" "$standby_host_ip" || exit 1
     check_evmserverd || { log_error "check_evmserverd failed"; exit 1; }
 
     log "Appliance configuration completed successfully for VM: $VM_NAME."
@@ -963,25 +1000,40 @@ fi
 
 setup_vm_resources
 
-appliance_configure
-
-log "First VM configuration completed successfully."
+# Store primary VM info for HA configuration
 primary_vmi_name=$vmi_name
+primary_vmi_ip=$vmi_ip
 
 # Deploy second VM if HA mode
 if [[ "$HA" == "true" ]]; then
+    # Now configure primary (no standby IP needed for primary)
+    log "=== Configuring PRIMARY VM ==="
+    vmi_name=$primary_vmi_name
+    vmi_ip=$primary_vmi_ip
+    appliance_configure "primary" "1" "" ""
+    log "Primary VM configuration completed successfully."
+
     log "=== Deploying STANDBY VM ==="
     set_vm_variables "standby"
     setup_vm_resources
-    log "Standby VM setup completed successfully (appliance configuration skipped)."
     standby_vmi_name=$vmi_name
+    standby_vmi_ip=$vmi_ip
+    log "Standby VM setup completed successfully."
+
+    # Configure standby with primary IP
+    log "=== Configuring STANDBY VM ==="
+    vmi_name=$standby_vmi_name
+    vmi_ip=$standby_vmi_ip
+    appliance_configure "standby" "2" "$primary_vmi_ip" "$standby_vmi_ip"
+    log "Standby VM configuration completed successfully."
 
     log "=== HA Deployment Complete ==="
     log "Full configuration log can be found at $LOG_FILE"
     log "Primary VM login: virtctl ssh root@vmi/$primary_vmi_name -n $NAMESPACE"
     log "Standby VM login: virtctl ssh root@vmi/$standby_vmi_name -n $NAMESPACE"
-    log "NOTE: Standby VM requires manual configuration."
 else
+    # Standard single VM deployment
+    appliance_configure "none" "" "" ""
     log "Standard deployment completed successfully."
     log "Full configuration log can be found at $LOG_FILE"
     log "To login: virtctl ssh root@vmi/$vmi_name -n $NAMESPACE"


### PR DESCRIPTION
* Use appliance_console_cli with ssh -c instead of expect / interactive for "configure application" (not run for standby as they only run a database for now)
* Convert set hostname expect / ssh interactive to use ssh -c
* Add replication options to the appliance_console_cli for primary/standby
* Cleanup / remove unneeded sleep / consolidate similarly named functions with one now just a wrapper around the other.

TODO:
* In a follow up, I'm going to remove the unnecessary comments and try to tidy up a bit as this PR is getting hard to follow. I did remove some of them from the commits that touched them here.
* The logging could be cleaned up so it's easier to read visually.  I started looking at making sure we have bookending of log messages here but will try to add that consistently for the rest of the code afterwards.
EDIT: (the prior two bullets are addressed in https://github.com/ManageIQ/manageiq-appliance-build/pull/599)
* There's more expect syntax being used to do interactive work that we can probably change to ssh -c.